### PR TITLE
feat: Add Gnosis Chain deployment support

### DIFF
--- a/.github/workflows/deploy-gnosis.yml
+++ b/.github/workflows/deploy-gnosis.yml
@@ -1,9 +1,6 @@
 name: Deploy to Gnosis Chain
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main

--- a/.github/workflows/deploy-gnosis.yml
+++ b/.github/workflows/deploy-gnosis.yml
@@ -88,22 +88,35 @@ jobs:
 
       - name: Verify contracts
         if: ${{ github.event.inputs.verify == 'true' || github.event.inputs.verify == null }}
-        continue-on-error: true
         run: |
           echo "Verifying VendingMachine at ${{ steps.deploy.outputs.VENDING_ADDRESS }}"
           
-          # Read constructor args from broadcast file
-          CONSTRUCTOR_ARGS=$(cat broadcast/DeployVendingMachine.s.sol/$CHAIN_ID/run-latest.json | jq -r '.transactions[] | select(.contractName == "VendingMachine") | .arguments')
+          # Extract constructor arguments from broadcast file
+          BROADCAST_FILE="broadcast/DeployVendingMachine.s.sol/$CHAIN_ID/run-latest.json"
+          echo "Reading constructor arguments from: $BROADCAST_FILE"
           
+          # Get the transaction that deployed VendingMachine
+          DEPLOY_TX=$(cat $BROADCAST_FILE | jq -r '.transactions[] | select(.contractName == "VendingMachine")')
+          
+          # Extract constructor arguments (removing the 0x prefix and bytecode)
+          # The arguments field contains the raw constructor arguments
+          CONSTRUCTOR_ARGS=$(echo "$DEPLOY_TX" | jq -r '.arguments' | sed 's/\[//g' | sed 's/\]//g' | sed 's/"//g' | sed 's/,//g' | sed 's/ //g')
+          
+          echo "Constructor arguments: $CONSTRUCTOR_ARGS"
+          
+          # Build the constructor arguments string for forge verify-contract
+          # The VendingMachine constructor takes multiple parameters, we need to encode them properly
           forge verify-contract \
+            ${{ steps.deploy.outputs.VENDING_ADDRESS }} \
+            src/contracts/VendingMachine.sol:VendingMachine \
             --chain-id $CHAIN_ID \
-            --watch \
             --etherscan-api-key $GNOSISSCAN_API \
-            --constructor-args $CONSTRUCTOR_ARGS \
             --compiler-version v0.8.20+commit.a1b79de6 \
             --verifier-url https://api.gnosisscan.io/api \
-            ${{ steps.deploy.outputs.VENDING_ADDRESS }} \
-            src/contracts/VendingMachine.sol:VendingMachine
+            --watch || {
+              echo "::error::Contract verification failed"
+              exit 1
+            }
 
       - name: Create deployment summary
         run: |

--- a/.github/workflows/deploy-gnosis.yml
+++ b/.github/workflows/deploy-gnosis.yml
@@ -91,6 +91,14 @@ jobs:
         run: |
           echo "Verifying VendingMachine at ${{ steps.deploy.outputs.VENDING_ADDRESS }}"
           
+          # Get compiler version from foundry.toml
+          SOLC_VERSION=$(grep 'solc_version' foundry.toml | cut -d'"' -f2)
+          echo "Using Solidity compiler version: $SOLC_VERSION"
+          
+          # Get the exact compiler version metadata from the compiled artifact
+          COMPILER_VERSION=$(cat out/VendingMachine.sol/VendingMachine.json | jq -r '.metadata.compiler.version')
+          echo "Exact compiler version from artifact: $COMPILER_VERSION"
+          
           # Extract constructor arguments from broadcast file
           BROADCAST_FILE="broadcast/DeployVendingMachine.s.sol/$CHAIN_ID/run-latest.json"
           echo "Reading constructor arguments from: $BROADCAST_FILE"
@@ -111,7 +119,7 @@ jobs:
             src/contracts/VendingMachine.sol:VendingMachine \
             --chain-id $CHAIN_ID \
             --etherscan-api-key $GNOSISSCAN_API \
-            --compiler-version v0.8.23+commit.f704f362 \
+            --compiler-version "v${COMPILER_VERSION}" \
             --verifier-url https://api.gnosisscan.io/api \
             --watch || {
               echo "::error::Contract verification failed"

--- a/.github/workflows/deploy-gnosis.yml
+++ b/.github/workflows/deploy-gnosis.yml
@@ -154,12 +154,20 @@ jobs:
           
           echo "$OUTPUT"
           
-          # Extract transaction hash from output if available
-          PURCHASE_TX=$(echo "$OUTPUT" | grep -o "hash: 0x[a-fA-F0-9]*" | head -1 | awk '{print $2}')
-          
-          if [ -n "$PURCHASE_TX" ]; then
+          # Extract the actual purchase transaction hash from broadcast file
+          # The second transaction in the array is the vendFromTrack call
+          BROADCAST_FILE="broadcast/PurchaseFromGnosis.s.sol/$CHAIN_ID/run-latest.json"
+          if [ -f "$BROADCAST_FILE" ]; then
+            # Get the hash of the vendFromTrack transaction (usually the second transaction)
+            PURCHASE_TX=$(cat $BROADCAST_FILE | jq -r '.transactions[] | select(.transaction.to == "'${{ steps.deploy.outputs.VENDING_ADDRESS }}'" and .transactionType == "CALL") | .hash' | head -1)
+            
+            if [ -z "$PURCHASE_TX" ]; then
+              # Fallback: get the last transaction hash
+              PURCHASE_TX=$(cat $BROADCAST_FILE | jq -r '.transactions[-1].hash')
+            fi
+            
             echo "PURCHASE_TX=$PURCHASE_TX" >> $GITHUB_OUTPUT
-            echo "Purchase transaction: $PURCHASE_TX"
+            echo "Purchase transaction hash: $PURCHASE_TX"
           else
             echo "Purchase simulation successful (no broadcast in test mode)"
           fi

--- a/.github/workflows/deploy-gnosis.yml
+++ b/.github/workflows/deploy-gnosis.yml
@@ -299,19 +299,68 @@ jobs:
               body: comment
             });
 
+      - name: Create release on main push
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        id: create_release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Generate version based on timestamp
+            const now = new Date();
+            const version = `v${now.getFullYear()}.${(now.getMonth() + 1).toString().padStart(2, '0')}.${now.getDate().toString().padStart(2, '0')}-${now.getHours().toString().padStart(2, '0')}${now.getMinutes().toString().padStart(2, '0')}`;
+            
+            const vendingAddress = '${{ steps.deploy.outputs.VENDING_ADDRESS }}';
+            const tokenAddress = '${{ steps.deploy.outputs.TOKEN_ADDRESS }}';
+            const deployTxHash = '${{ steps.deploy.outputs.DEPLOY_TX_HASH }}';
+            const purchaseTx = '${{ steps.test-purchase.outputs.PURCHASE_TX }}';
+            const explorerUrl = '${{ steps.network-env.outputs.EXPLORER_URL }}';
+            
+            const releaseBody = `## 🎉 Gnosis Chain Deployment
+            
+            ### Contract Addresses
+            **VendingMachine**: [${vendingAddress}](${explorerUrl}/address/${vendingAddress})
+            **VoteToken**: [${tokenAddress}](${explorerUrl}/address/${tokenAddress})
+            
+            ### Transaction Details
+            📝 **Deployment Tx**: [${deployTxHash}](${explorerUrl}/tx/${deployTxHash})
+            ${purchaseTx ? `✅ **Test Purchase Tx**: [${purchaseTx}](${explorerUrl}/tx/${purchaseTx})` : '✅ **Test Purchase**: Validated'}
+            
+            ### Deployment Info
+            - **Network**: Gnosis Chain (Chain ID: 100)
+            - **Commit**: ${context.sha}
+            - **Timestamp**: ${new Date().toISOString()}
+            
+            ### 📦 Deployment Artifact
+            Download \`deployment-gnosis.json\` from the release assets for programmatic access to contract addresses.`;
+            
+            const release = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: version,
+              name: `Gnosis Deployment ${version}`,
+              body: releaseBody,
+              draft: false,
+              prerelease: false,
+              target_commitish: context.sha
+            });
+            
+            core.setOutput('release_id', release.data.id);
+            core.setOutput('upload_url', release.data.upload_url);
+            console.log(`Created release ${version}`);
+
       - name: Upload deployment artifact to release
-        if: github.event_name == 'release'
+        if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ github.event.release.upload_url }}
+          upload_url: ${{ github.event.release.upload_url || steps.create_release.outputs.upload_url }}
           asset_path: ./deployment-gnosis.json
           asset_name: deployment-gnosis.json
           asset_content_type: application/json
 
       - name: Create release deployment summary
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' && github.event_name != 'push'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/deploy-gnosis.yml
+++ b/.github/workflows/deploy-gnosis.yml
@@ -77,8 +77,18 @@ jobs:
           VENDING_ADDRESS=$(echo "$OUTPUT" | grep -o "VendingMachine deployed at: 0x[a-fA-F0-9]*" | awk '{print $4}')
           TOKEN_ADDRESS=$(echo "$OUTPUT" | grep -o "VoteToken deployed at: 0x[a-fA-F0-9]*" | awk '{print $4}')
           
+          # Extract transaction hash from broadcast file
+          BROADCAST_FILE="broadcast/DeployVendingMachine.s.sol/$CHAIN_ID/run-latest.json"
+          if [ -f "$BROADCAST_FILE" ]; then
+            DEPLOY_TX_HASH=$(cat $BROADCAST_FILE | jq -r '.transactions[] | select(.contractName == "VendingMachine") | .hash' | head -1)
+            echo "Deployment transaction hash: $DEPLOY_TX_HASH"
+          else
+            DEPLOY_TX_HASH=""
+          fi
+          
           echo "VENDING_ADDRESS=$VENDING_ADDRESS" >> $GITHUB_OUTPUT
           echo "TOKEN_ADDRESS=$TOKEN_ADDRESS" >> $GITHUB_OUTPUT
+          echo "DEPLOY_TX_HASH=$DEPLOY_TX_HASH" >> $GITHUB_OUTPUT
 
       - name: Wait for blockchain indexing
         if: ${{ github.event.inputs.verify == 'true' || github.event.inputs.verify == null }}
@@ -169,6 +179,9 @@ jobs:
           echo "- Deployer: \`${{ secrets.MAINNET_DEPLOYER_ADDRESS }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Timestamp: $(date -u +"%Y-%m-%d %H:%M:%S UTC")" >> $GITHUB_STEP_SUMMARY
           echo "- Commit: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          if [ -n "${{ steps.deploy.outputs.DEPLOY_TX_HASH }}" ]; then
+            echo "- Deployment Tx: [\`${{ steps.deploy.outputs.DEPLOY_TX_HASH }}\`](${{ steps.network-env.outputs.EXPLORER_URL }}/tx/${{ steps.deploy.outputs.DEPLOY_TX_HASH }})" >> $GITHUB_STEP_SUMMARY
+          fi
           if [ "${{ github.event_name }}" == "release" ]; then
             echo "- Release: \`${{ github.event.release.tag_name }}\`" >> $GITHUB_STEP_SUMMARY
           fi
@@ -195,22 +208,29 @@ jobs:
           script: |
             const vendingAddress = '${{ steps.deploy.outputs.VENDING_ADDRESS }}';
             const tokenAddress = '${{ steps.deploy.outputs.TOKEN_ADDRESS }}';
+            const deployTxHash = '${{ steps.deploy.outputs.DEPLOY_TX_HASH }}';
             const explorerUrl = '${{ steps.network-env.outputs.EXPLORER_URL }}';
             const purchaseTx = '${{ steps.test-purchase.outputs.PURCHASE_TX }}';
             
             let comment = `## 🚀 Deployed to Gnosis Chain
             
+            ### Contract Addresses
             **VendingMachine**: [${vendingAddress}](${explorerUrl}/address/${vendingAddress})
             **VoteToken**: [${tokenAddress}](${explorerUrl}/address/${tokenAddress})
-            `;
+            
+            ### Transaction Details`;
+            
+            if (deployTxHash) {
+              comment += `\n📝 **Deployment Tx**: [${deployTxHash}](${explorerUrl}/tx/${deployTxHash})`;
+            }
             
             if (purchaseTx) {
-              comment += `\n✅ **Test Purchase**: [${purchaseTx}](${explorerUrl}/tx/${purchaseTx})`;
+              comment += `\n✅ **Test Purchase Tx**: [${purchaseTx}](${explorerUrl}/tx/${purchaseTx})`;
             } else {
               comment += `\n✅ **Test Purchase**: Validated successfully`;
             }
             
-            comment += `\n\nDeployed from commit: ${context.sha}`;
+            comment += `\n\n**Deployed from commit**: ${context.sha}`;
             
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/deploy-gnosis.yml
+++ b/.github/workflows/deploy-gnosis.yml
@@ -111,7 +111,7 @@ jobs:
             src/contracts/VendingMachine.sol:VendingMachine \
             --chain-id $CHAIN_ID \
             --etherscan-api-key $GNOSISSCAN_API \
-            --compiler-version v0.8.20+commit.a1b79de6 \
+            --compiler-version v0.8.23+commit.f704f362 \
             --verifier-url https://api.gnosisscan.io/api \
             --watch || {
               echo "::error::Contract verification failed"

--- a/.github/workflows/deploy-gnosis.yml
+++ b/.github/workflows/deploy-gnosis.yml
@@ -164,6 +164,42 @@ jobs:
             echo "Purchase simulation successful (no broadcast in test mode)"
           fi
 
+      - name: Create deployment artifact JSON
+        id: create-artifact
+        run: |
+          # Create deployment artifact JSON
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          
+          cat > deployment-gnosis.json << EOF
+          {
+            "network": "gnosis",
+            "chainId": 100,
+            "contracts": {
+              "vendingMachine": "${{ steps.deploy.outputs.VENDING_ADDRESS }}",
+              "voteToken": "${{ steps.deploy.outputs.TOKEN_ADDRESS }}"
+            },
+            "transactions": {
+              "deployment": "${{ steps.deploy.outputs.DEPLOY_TX_HASH }}",
+              "testPurchase": "${{ steps.test-purchase.outputs.PURCHASE_TX }}"
+            },
+            "metadata": {
+              "timestamp": "$TIMESTAMP",
+              "commitHash": "${{ github.sha }}",
+              "deployer": "${{ secrets.MAINNET_DEPLOYER_ADDRESS }}",
+              "rpcUrl": "https://rpc.gnosischain.com",
+              "explorerUrl": "https://gnosisscan.io",
+              "acceptedTokens": ["0xa555d5344f6FB6c65da19e403Cb4c1eC4a1a5Ee3"]
+            },
+            "version": "${{ github.event.release.tag_name || github.run_number }}",
+            "abi": {
+              "vendingMachine": "https://github.com/communetxyz/mutual-vend-sc/blob/${{ github.sha }}/src/interfaces/IVendingMachine.sol"
+            }
+          }
+          EOF
+          
+          echo "Deployment artifact created: deployment-gnosis.json"
+          cat deployment-gnosis.json
+
       - name: Create deployment summary
         run: |
           echo "## 🚀 Deployment Summary" >> $GITHUB_STEP_SUMMARY
@@ -200,6 +236,7 @@ jobs:
           path: |
             broadcast/
             out/
+            deployment-gnosis.json
 
       - name: Comment on PR (if applicable)
         if: github.event_name == 'pull_request'
@@ -239,6 +276,17 @@ jobs:
               body: comment
             });
 
+      - name: Upload deployment artifact to release
+        if: github.event_name == 'release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./deployment-gnosis.json
+          asset_name: deployment-gnosis.json
+          asset_content_type: application/json
+
       - name: Create release deployment summary
         if: github.event_name == 'release'
         uses: actions/github-script@v7
@@ -247,15 +295,21 @@ jobs:
             const vendingAddress = '${{ steps.deploy.outputs.VENDING_ADDRESS }}';
             const tokenAddress = '${{ steps.deploy.outputs.TOKEN_ADDRESS }}';
             const explorerUrl = '${{ steps.network-env.outputs.EXPLORER_URL }}';
+            const deployTxHash = '${{ steps.deploy.outputs.DEPLOY_TX_HASH }}';
             
             const body = `## 🎉 Gnosis Chain Deployment
             
             **VendingMachine**: [${vendingAddress}](${explorerUrl}/address/${vendingAddress})
             **VoteToken**: [${tokenAddress}](${explorerUrl}/address/${tokenAddress})
             
+            **Deployment Tx**: [${deployTxHash}](${explorerUrl}/tx/${deployTxHash})
+            
             **Network**: Gnosis Chain (Chain ID: 100)
             **Deployed from**: ${context.sha}
-            **Timestamp**: ${new Date().toISOString()}`;
+            **Timestamp**: ${new Date().toISOString()}
+            
+            ### 📦 Deployment Artifact
+            Download \`deployment-gnosis.json\` from the release assets for programmatic access to contract addresses.`;
             
             await github.rest.repos.updateRelease({
               owner: context.repo.owner,

--- a/.github/workflows/deploy-gnosis.yml
+++ b/.github/workflows/deploy-gnosis.yml
@@ -144,13 +144,27 @@ jobs:
           # Export the VendingMachine address for the purchase script
           export VENDING_MACHINE_ADDRESS=${{ steps.deploy.outputs.VENDING_ADDRESS }}
           
-          # Run the purchase script
+          # Check if deployer has token balance
+          DEPLOYER_ADDRESS="${{ secrets.MAINNET_DEPLOYER_ADDRESS }}"
+          TOKEN_ADDRESS="0xa555d5344f6FB6c65da19e403Cb4c1eC4a1a5Ee3"
+          
+          echo "Checking token balance for deployer: $DEPLOYER_ADDRESS"
+          TOKEN_BALANCE=$(cast call $TOKEN_ADDRESS "balanceOf(address)(uint256)" $DEPLOYER_ADDRESS --rpc-url $RPC_URL)
+          echo "Token balance: $TOKEN_BALANCE"
+          
+          # Run the purchase script - it will fail if insufficient balance
           OUTPUT=$(forge script script/PurchaseFromGnosis.s.sol:PurchaseFromGnosis \
             --rpc-url $RPC_URL \
             --broadcast \
             --slow \
             --legacy \
-            -vvv)
+            -vvv) || {
+            echo "::error::Purchase test failed. Ensure deployer has sufficient token balance."
+            echo "::error::Deployer: $DEPLOYER_ADDRESS"
+            echo "::error::Token: $TOKEN_ADDRESS"
+            echo "::error::Balance: $TOKEN_BALANCE"
+            exit 1
+          }
           
           echo "$OUTPUT"
           
@@ -166,10 +180,14 @@ jobs:
               PURCHASE_TX=$(cat $BROADCAST_FILE | jq -r '.transactions[-1].hash')
             fi
             
-            echo "PURCHASE_TX=$PURCHASE_TX" >> $GITHUB_OUTPUT
-            echo "Purchase transaction hash: $PURCHASE_TX"
+            if [ -n "$PURCHASE_TX" ] && [ "$PURCHASE_TX" != "null" ]; then
+              echo "PURCHASE_TX=$PURCHASE_TX" >> $GITHUB_OUTPUT
+              echo "Purchase transaction hash: $PURCHASE_TX"
+            else
+              echo "::warning::No purchase transaction found, but script succeeded"
+            fi
           else
-            echo "Purchase simulation successful (no broadcast in test mode)"
+            echo "::warning::No broadcast file found for purchase test"
           fi
 
       - name: Create deployment artifact JSON

--- a/.github/workflows/deploy-gnosis.yml
+++ b/.github/workflows/deploy-gnosis.yml
@@ -126,6 +126,34 @@ jobs:
               exit 1
             }
 
+      - name: Test purchase from VendingMachine
+        id: test-purchase
+        run: |
+          echo "Testing purchase from newly deployed VendingMachine..."
+          
+          # Export the VendingMachine address for the purchase script
+          export VENDING_MACHINE_ADDRESS=${{ steps.deploy.outputs.VENDING_ADDRESS }}
+          
+          # Run the purchase script
+          OUTPUT=$(forge script script/PurchaseFromGnosis.s.sol:PurchaseFromGnosis \
+            --rpc-url $RPC_URL \
+            --broadcast \
+            --slow \
+            --legacy \
+            -vvv)
+          
+          echo "$OUTPUT"
+          
+          # Extract transaction hash from output if available
+          PURCHASE_TX=$(echo "$OUTPUT" | grep -o "hash: 0x[a-fA-F0-9]*" | head -1 | awk '{print $2}')
+          
+          if [ -n "$PURCHASE_TX" ]; then
+            echo "PURCHASE_TX=$PURCHASE_TX" >> $GITHUB_OUTPUT
+            echo "Purchase transaction: $PURCHASE_TX"
+          else
+            echo "Purchase simulation successful (no broadcast in test mode)"
+          fi
+
       - name: Create deployment summary
         run: |
           echo "## 🚀 Deployment Summary" >> $GITHUB_STEP_SUMMARY
@@ -144,6 +172,13 @@ jobs:
           if [ "${{ github.event_name }}" == "release" ]; then
             echo "- Release: \`${{ github.event.release.tag_name }}\`" >> $GITHUB_STEP_SUMMARY
           fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Test Purchase" >> $GITHUB_STEP_SUMMARY
+          if [ -n "${{ steps.test-purchase.outputs.PURCHASE_TX }}" ]; then
+            echo "✅ Test purchase successful: [\`${{ steps.test-purchase.outputs.PURCHASE_TX }}\`](${{ steps.network-env.outputs.EXPLORER_URL }}/tx/${{ steps.test-purchase.outputs.PURCHASE_TX }})" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "✅ Purchase script validated successfully" >> $GITHUB_STEP_SUMMARY
+          fi
 
       - name: Save deployment artifacts
         uses: actions/upload-artifact@v4
@@ -161,13 +196,21 @@ jobs:
             const vendingAddress = '${{ steps.deploy.outputs.VENDING_ADDRESS }}';
             const tokenAddress = '${{ steps.deploy.outputs.TOKEN_ADDRESS }}';
             const explorerUrl = '${{ steps.network-env.outputs.EXPLORER_URL }}';
+            const purchaseTx = '${{ steps.test-purchase.outputs.PURCHASE_TX }}';
             
-            const comment = `## 🚀 Deployed to Gnosis Chain
+            let comment = `## 🚀 Deployed to Gnosis Chain
             
             **VendingMachine**: [${vendingAddress}](${explorerUrl}/address/${vendingAddress})
             **VoteToken**: [${tokenAddress}](${explorerUrl}/address/${tokenAddress})
+            `;
             
-            Deployed from commit: ${context.sha}`;
+            if (purchaseTx) {
+              comment += `\n✅ **Test Purchase**: [${purchaseTx}](${explorerUrl}/tx/${purchaseTx})`;
+            } else {
+              comment += `\n✅ **Test Purchase**: Validated successfully`;
+            }
+            
+            comment += `\n\nDeployed from commit: ${context.sha}`;
             
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/deploy-gnosis.yml
+++ b/.github/workflows/deploy-gnosis.yml
@@ -144,8 +144,8 @@ jobs:
           # Export the VendingMachine address for the purchase script
           export VENDING_MACHINE_ADDRESS=${{ steps.deploy.outputs.VENDING_ADDRESS }}
           
-          # Check if deployer has token balance
-          DEPLOYER_ADDRESS="${{ secrets.MAINNET_DEPLOYER_ADDRESS }}"
+          # Get deployer address from private key
+          DEPLOYER_ADDRESS=$(cast wallet address $PRIVATE_KEY)
           TOKEN_ADDRESS="0xa555d5344f6FB6c65da19e403Cb4c1eC4a1a5Ee3"
           
           echo "Checking token balance for deployer: $DEPLOYER_ADDRESS"
@@ -211,7 +211,7 @@ jobs:
             "metadata": {
               "timestamp": "$TIMESTAMP",
               "commitHash": "${{ github.sha }}",
-              "deployer": "${{ secrets.MAINNET_DEPLOYER_ADDRESS }}",
+              "deployer": "$(cast wallet address $PRIVATE_KEY)",
               "rpcUrl": "https://rpc.gnosischain.com",
               "explorerUrl": "https://gnosisscan.io",
               "acceptedTokens": ["0xa555d5344f6FB6c65da19e403Cb4c1eC4a1a5Ee3"]
@@ -238,7 +238,7 @@ jobs:
           echo "| VoteToken | \`${{ steps.deploy.outputs.TOKEN_ADDRESS }}\` | [View](${{ steps.network-env.outputs.EXPLORER_URL }}/address/${{ steps.deploy.outputs.TOKEN_ADDRESS }}) |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Deployment Details" >> $GITHUB_STEP_SUMMARY
-          echo "- Deployer: \`${{ secrets.MAINNET_DEPLOYER_ADDRESS }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Deployer: \`$(cast wallet address $PRIVATE_KEY)\`" >> $GITHUB_STEP_SUMMARY
           echo "- Timestamp: $(date -u +"%Y-%m-%d %H:%M:%S UTC")" >> $GITHUB_STEP_SUMMARY
           echo "- Commit: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
           if [ -n "${{ steps.deploy.outputs.DEPLOY_TX_HASH }}" ]; then

--- a/.github/workflows/deploy-gnosis.yml
+++ b/.github/workflows/deploy-gnosis.yml
@@ -1,0 +1,181 @@
+name: Deploy to Gnosis Chain
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      verify:
+        description: 'Verify contracts on Gnosisscan'
+        required: false
+        default: true
+        type: boolean
+
+env:
+  FOUNDRY_PROFILE: default
+
+jobs:
+  deploy:
+    name: Deploy VendingMachine to Gnosis Chain
+    runs-on: ubuntu-latest
+    environment: gnosis-mainnet
+    permissions:
+      contents: read
+      pull-requests: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build contracts
+        run: forge build
+
+      - name: Set environment
+        id: network-env
+        run: |
+          echo "RPC_URL=${{ secrets.GNOSIS_RPC_URL }}" >> $GITHUB_ENV
+          echo "GNOSISSCAN_API=${{ secrets.GNOSISSCAN_API_KEY }}" >> $GITHUB_ENV
+          echo "CHAIN_ID=100" >> $GITHUB_ENV
+          echo "EXPLORER_URL=https://gnosisscan.io" >> $GITHUB_OUTPUT
+          echo "PRIVATE_KEY=${{ secrets.MAINNET_DEPLOYER_PRIVATE_KEY }}" >> $GITHUB_ENV
+
+      - name: Deploy VendingMachine
+        id: deploy
+        run: |
+          OUTPUT=$(forge script script/DeployVendingMachine.s.sol:DeployVendingMachine \
+            --rpc-url $RPC_URL \
+            --broadcast \
+            --slow \
+            --legacy \
+            -vvv)
+          
+          echo "$OUTPUT"
+          
+          # Extract deployed addresses from output
+          VENDING_ADDRESS=$(echo "$OUTPUT" | grep -o "VendingMachine deployed at: 0x[a-fA-F0-9]*" | awk '{print $4}')
+          TOKEN_ADDRESS=$(echo "$OUTPUT" | grep -o "VoteToken deployed at: 0x[a-fA-F0-9]*" | awk '{print $4}')
+          
+          echo "VENDING_ADDRESS=$VENDING_ADDRESS" >> $GITHUB_OUTPUT
+          echo "TOKEN_ADDRESS=$TOKEN_ADDRESS" >> $GITHUB_OUTPUT
+
+      - name: Wait for blockchain indexing
+        if: ${{ github.event.inputs.verify == 'true' || github.event.inputs.verify == null }}
+        run: |
+          echo "Waiting 60 seconds for blockchain indexing..."
+          sleep 60
+
+      - name: Verify contracts
+        if: ${{ github.event.inputs.verify == 'true' || github.event.inputs.verify == null }}
+        continue-on-error: true
+        run: |
+          echo "Verifying VendingMachine at ${{ steps.deploy.outputs.VENDING_ADDRESS }}"
+          
+          # Read constructor args from broadcast file
+          CONSTRUCTOR_ARGS=$(cat broadcast/DeployVendingMachine.s.sol/$CHAIN_ID/run-latest.json | jq -r '.transactions[] | select(.contractName == "VendingMachine") | .arguments')
+          
+          forge verify-contract \
+            --chain-id $CHAIN_ID \
+            --watch \
+            --etherscan-api-key $GNOSISSCAN_API \
+            --constructor-args $CONSTRUCTOR_ARGS \
+            --compiler-version v0.8.20+commit.a1b79de6 \
+            --verifier-url https://api.gnosisscan.io/api \
+            ${{ steps.deploy.outputs.VENDING_ADDRESS }} \
+            src/contracts/VendingMachine.sol:VendingMachine
+
+      - name: Create deployment summary
+        run: |
+          echo "## 🚀 Deployment Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Network: Gnosis Chain (Mainnet)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Contract | Address | Explorer |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|---------|----------|" >> $GITHUB_STEP_SUMMARY
+          echo "| VendingMachine | \`${{ steps.deploy.outputs.VENDING_ADDRESS }}\` | [View](${{ steps.network-env.outputs.EXPLORER_URL }}/address/${{ steps.deploy.outputs.VENDING_ADDRESS }}) |" >> $GITHUB_STEP_SUMMARY
+          echo "| VoteToken | \`${{ steps.deploy.outputs.TOKEN_ADDRESS }}\` | [View](${{ steps.network-env.outputs.EXPLORER_URL }}/address/${{ steps.deploy.outputs.TOKEN_ADDRESS }}) |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Deployment Details" >> $GITHUB_STEP_SUMMARY
+          echo "- Deployer: \`${{ secrets.MAINNET_DEPLOYER_ADDRESS }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Timestamp: $(date -u +"%Y-%m-%d %H:%M:%S UTC")" >> $GITHUB_STEP_SUMMARY
+          echo "- Commit: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ github.event_name }}" == "release" ]; then
+            echo "- Release: \`${{ github.event.release.tag_name }}\`" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Save deployment artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: deployment-gnosis-${{ github.run_number }}
+          path: |
+            broadcast/
+            out/
+
+      - name: Comment on PR (if applicable)
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const vendingAddress = '${{ steps.deploy.outputs.VENDING_ADDRESS }}';
+            const tokenAddress = '${{ steps.deploy.outputs.TOKEN_ADDRESS }}';
+            const explorerUrl = '${{ steps.network-env.outputs.EXPLORER_URL }}';
+            
+            const comment = `## 🚀 Deployed to Gnosis Chain
+            
+            **VendingMachine**: [${vendingAddress}](${explorerUrl}/address/${vendingAddress})
+            **VoteToken**: [${tokenAddress}](${explorerUrl}/address/${tokenAddress})
+            
+            Deployed from commit: ${context.sha}`;
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });
+
+      - name: Create release deployment summary
+        if: github.event_name == 'release'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const vendingAddress = '${{ steps.deploy.outputs.VENDING_ADDRESS }}';
+            const tokenAddress = '${{ steps.deploy.outputs.TOKEN_ADDRESS }}';
+            const explorerUrl = '${{ steps.network-env.outputs.EXPLORER_URL }}';
+            
+            const body = `## 🎉 Gnosis Chain Deployment
+            
+            **VendingMachine**: [${vendingAddress}](${explorerUrl}/address/${vendingAddress})
+            **VoteToken**: [${tokenAddress}](${explorerUrl}/address/${tokenAddress})
+            
+            **Network**: Gnosis Chain (Chain ID: 100)
+            **Deployed from**: ${context.sha}
+            **Timestamp**: ${new Date().toISOString()}`;
+            
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: context.payload.release.id,
+              body: context.payload.release.body + '\n\n---\n\n' + body
+            });

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -85,21 +85,34 @@ jobs:
 
       - name: Verify contracts
         if: ${{ github.event.inputs.verify == 'true' || github.event.inputs.verify == null }}
-        continue-on-error: true
         run: |
           echo "Verifying VendingMachine at ${{ steps.deploy.outputs.VENDING_ADDRESS }}"
           
-          # Read constructor args from broadcast file
-          CONSTRUCTOR_ARGS=$(cat broadcast/DeployVendingMachine.s.sol/$CHAIN_ID/run-latest.json | jq -r '.transactions[] | select(.contractName == "VendingMachine") | .arguments')
+          # Extract constructor arguments from broadcast file
+          BROADCAST_FILE="broadcast/DeployVendingMachine.s.sol/$CHAIN_ID/run-latest.json"
+          echo "Reading constructor arguments from: $BROADCAST_FILE"
           
+          # Get the transaction that deployed VendingMachine
+          DEPLOY_TX=$(cat $BROADCAST_FILE | jq -r '.transactions[] | select(.contractName == "VendingMachine")')
+          
+          # Extract constructor arguments (removing the 0x prefix and bytecode)
+          # The arguments field contains the raw constructor arguments
+          CONSTRUCTOR_ARGS=$(echo "$DEPLOY_TX" | jq -r '.arguments' | sed 's/\[//g' | sed 's/\]//g' | sed 's/"//g' | sed 's/,//g' | sed 's/ //g')
+          
+          echo "Constructor arguments: $CONSTRUCTOR_ARGS"
+          
+          # Build the constructor arguments string for forge verify-contract
+          # The VendingMachine constructor takes multiple parameters, we need to encode them properly
           forge verify-contract \
-            --chain-id $CHAIN_ID \
-            --watch \
-            --etherscan-api-key $ETHERSCAN_API \
-            --constructor-args $CONSTRUCTOR_ARGS \
-            --compiler-version v0.8.20+commit.a1b79de6 \
             ${{ steps.deploy.outputs.VENDING_ADDRESS }} \
-            src/contracts/VendingMachine.sol:VendingMachine
+            src/contracts/VendingMachine.sol:VendingMachine \
+            --chain-id $CHAIN_ID \
+            --etherscan-api-key $ETHERSCAN_API \
+            --compiler-version v0.8.20+commit.a1b79de6 \
+            --watch || {
+              echo "::error::Contract verification failed"
+              exit 1
+            }
 
       - name: Create deployment summary
         run: |

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -88,6 +88,14 @@ jobs:
         run: |
           echo "Verifying VendingMachine at ${{ steps.deploy.outputs.VENDING_ADDRESS }}"
           
+          # Get compiler version from foundry.toml
+          SOLC_VERSION=$(grep 'solc_version' foundry.toml | cut -d'"' -f2)
+          echo "Using Solidity compiler version: $SOLC_VERSION"
+          
+          # Get the exact compiler version metadata from the compiled artifact
+          COMPILER_VERSION=$(cat out/VendingMachine.sol/VendingMachine.json | jq -r '.metadata.compiler.version')
+          echo "Exact compiler version from artifact: $COMPILER_VERSION"
+          
           # Extract constructor arguments from broadcast file
           BROADCAST_FILE="broadcast/DeployVendingMachine.s.sol/$CHAIN_ID/run-latest.json"
           echo "Reading constructor arguments from: $BROADCAST_FILE"
@@ -108,7 +116,7 @@ jobs:
             src/contracts/VendingMachine.sol:VendingMachine \
             --chain-id $CHAIN_ID \
             --etherscan-api-key $ETHERSCAN_API \
-            --compiler-version v0.8.23+commit.f704f362 \
+            --compiler-version "v${COMPILER_VERSION}" \
             --watch || {
               echo "::error::Contract verification failed"
               exit 1

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -108,7 +108,7 @@ jobs:
             src/contracts/VendingMachine.sol:VendingMachine \
             --chain-id $CHAIN_ID \
             --etherscan-api-key $ETHERSCAN_API \
-            --compiler-version v0.8.20+commit.a1b79de6 \
+            --compiler-version v0.8.23+commit.f704f362 \
             --watch || {
               echo "::error::Contract verification failed"
               exit 1

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -276,6 +276,364 @@ NEXT_PUBLIC_CHAIN_ID=${deployment.chainId}
 updateEnv();
 ```
 
+## Python Integration
+
+### Using requests library
+
+```python
+import requests
+import json
+
+def get_latest_deployment():
+    """Fetch the latest deployment addresses from GitHub releases."""
+    try:
+        # Get latest release
+        response = requests.get(
+            'https://api.github.com/repos/communetxyz/mutual-vend-sc/releases/latest'
+        )
+        response.raise_for_status()
+        release = response.json()
+        
+        # Find the deployment artifact
+        deployment_asset = None
+        for asset in release.get('assets', []):
+            if asset['name'] == 'deployment-gnosis.json':
+                deployment_asset = asset
+                break
+        
+        if not deployment_asset:
+            raise ValueError('Deployment artifact not found')
+        
+        # Download the deployment artifact
+        artifact_response = requests.get(deployment_asset['browser_download_url'])
+        artifact_response.raise_for_status()
+        
+        return artifact_response.json()
+    
+    except requests.RequestException as e:
+        print(f"Failed to fetch deployment: {e}")
+        raise
+
+# Usage
+deployment = get_latest_deployment()
+print(f"VendingMachine address: {deployment['contracts']['vendingMachine']}")
+print(f"VoteToken address: {deployment['contracts']['voteToken']}")
+print(f"Chain ID: {deployment['chainId']}")
+print(f"RPC URL: {deployment['metadata']['rpcUrl']}")
+```
+
+### Using async with aiohttp
+
+```python
+import aiohttp
+import asyncio
+
+async def get_latest_deployment_async():
+    """Asynchronously fetch the latest deployment addresses."""
+    async with aiohttp.ClientSession() as session:
+        # Get latest release
+        async with session.get(
+            'https://api.github.com/repos/communetxyz/mutual-vend-sc/releases/latest'
+        ) as response:
+            release = await response.json()
+        
+        # Find deployment artifact
+        deployment_asset = next(
+            (asset for asset in release.get('assets', []) 
+             if asset['name'] == 'deployment-gnosis.json'),
+            None
+        )
+        
+        if not deployment_asset:
+            raise ValueError('Deployment artifact not found')
+        
+        # Download the artifact
+        async with session.get(deployment_asset['browser_download_url']) as artifact_response:
+            return await artifact_response.json()
+
+# Usage
+async def main():
+    deployment = await get_latest_deployment_async()
+    print(f"Contracts: {deployment['contracts']}")
+
+asyncio.run(main())
+```
+
+### Web3.py Integration
+
+```python
+from web3 import Web3
+import requests
+import json
+
+class VendingMachineClient:
+    def __init__(self):
+        self.deployment = self._fetch_deployment()
+        self.w3 = Web3(Web3.HTTPProvider(self.deployment['metadata']['rpcUrl']))
+        self.vending_machine_address = self.deployment['contracts']['vendingMachine']
+        self.vote_token_address = self.deployment['contracts']['voteToken']
+        
+        # Load ABI (you'll need to provide this)
+        self.abi = self._load_abi()
+        
+        # Create contract instance
+        self.contract = self.w3.eth.contract(
+            address=self.vending_machine_address,
+            abi=self.abi
+        )
+    
+    def _fetch_deployment(self):
+        """Fetch deployment configuration from GitHub."""
+        response = requests.get(
+            'https://api.github.com/repos/communetxyz/mutual-vend-sc/releases/latest'
+        )
+        release = response.json()
+        
+        asset = next(
+            (a for a in release['assets'] if a['name'] == 'deployment-gnosis.json'),
+            None
+        )
+        
+        if not asset:
+            raise ValueError('Deployment not found')
+        
+        return requests.get(asset['browser_download_url']).json()
+    
+    def _load_abi(self):
+        # Load ABI from file or fetch from GitHub
+        # This is a placeholder - replace with actual ABI loading
+        return []
+    
+    def get_track(self, track_id):
+        """Get track information from the vending machine."""
+        return self.contract.functions.getTrack(track_id).call()
+    
+    def get_balance(self, address):
+        """Get vote token balance for an address."""
+        vote_token = self.w3.eth.contract(
+            address=self.vote_token_address,
+            abi=self.abi  # Use ERC20 ABI
+        )
+        return vote_token.functions.balanceOf(address).call()
+
+# Usage
+client = VendingMachineClient()
+track_info = client.get_track(0)
+print(f"Track 0: {track_info}")
+```
+
+### Dataclass for Type Safety
+
+```python
+from dataclasses import dataclass
+from typing import List, Optional, Dict
+import requests
+from datetime import datetime
+
+@dataclass
+class Contracts:
+    vending_machine: str
+    vote_token: str
+
+@dataclass
+class Transactions:
+    deployment: str
+    test_purchase: Optional[str] = None
+
+@dataclass
+class Metadata:
+    timestamp: datetime
+    commit_hash: str
+    deployer: str
+    rpc_url: str
+    explorer_url: str
+    accepted_tokens: List[str]
+
+@dataclass
+class DeploymentArtifact:
+    network: str
+    chain_id: int
+    contracts: Contracts
+    transactions: Transactions
+    metadata: Metadata
+    version: str
+    abi: Dict[str, str]
+    
+    @classmethod
+    def from_github(cls):
+        """Fetch and parse deployment from GitHub releases."""
+        response = requests.get(
+            'https://api.github.com/repos/communetxyz/mutual-vend-sc/releases/latest'
+        )
+        release = response.json()
+        
+        asset = next(
+            (a for a in release['assets'] if a['name'] == 'deployment-gnosis.json'),
+            None
+        )
+        
+        if not asset:
+            raise ValueError('Deployment artifact not found')
+        
+        data = requests.get(asset['browser_download_url']).json()
+        
+        return cls(
+            network=data['network'],
+            chain_id=data['chainId'],
+            contracts=Contracts(
+                vending_machine=data['contracts']['vendingMachine'],
+                vote_token=data['contracts']['voteToken']
+            ),
+            transactions=Transactions(
+                deployment=data['transactions']['deployment'],
+                test_purchase=data['transactions'].get('testPurchase')
+            ),
+            metadata=Metadata(
+                timestamp=datetime.fromisoformat(data['metadata']['timestamp'].replace('Z', '+00:00')),
+                commit_hash=data['metadata']['commitHash'],
+                deployer=data['metadata']['deployer'],
+                rpc_url=data['metadata']['rpcUrl'],
+                explorer_url=data['metadata']['explorerUrl'],
+                accepted_tokens=data['metadata']['acceptedTokens']
+            ),
+            version=data['version'],
+            abi=data['abi']
+        )
+
+# Usage
+deployment = DeploymentArtifact.from_github()
+print(f"VendingMachine: {deployment.contracts.vending_machine}")
+print(f"Deployed at: {deployment.metadata.timestamp}")
+print(f"Chain: {deployment.network} (ID: {deployment.chain_id})")
+```
+
+### CLI Tool Example
+
+```python
+#!/usr/bin/env python3
+"""
+CLI tool to fetch and display deployment information.
+Save as: get_deployment.py
+"""
+
+import argparse
+import json
+import requests
+from typing import Optional
+
+def get_deployment(format: str = 'json', contract: Optional[str] = None):
+    """Fetch deployment information."""
+    response = requests.get(
+        'https://api.github.com/repos/communetxyz/mutual-vend-sc/releases/latest'
+    )
+    release = response.json()
+    
+    asset = next(
+        (a for a in release['assets'] if a['name'] == 'deployment-gnosis.json'),
+        None
+    )
+    
+    if not asset:
+        raise ValueError('Deployment not found')
+    
+    deployment = requests.get(asset['browser_download_url']).json()
+    
+    if contract:
+        return deployment['contracts'].get(contract, 'Contract not found')
+    
+    if format == 'json':
+        return json.dumps(deployment, indent=2)
+    elif format == 'env':
+        return f"""
+VENDING_MACHINE_ADDRESS={deployment['contracts']['vendingMachine']}
+VOTE_TOKEN_ADDRESS={deployment['contracts']['voteToken']}
+GNOSIS_RPC_URL={deployment['metadata']['rpcUrl']}
+CHAIN_ID={deployment['chainId']}
+""".strip()
+    else:
+        return deployment
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Fetch Gnosis deployment addresses')
+    parser.add_argument('--format', choices=['json', 'env'], default='json',
+                        help='Output format')
+    parser.add_argument('--contract', choices=['vendingMachine', 'voteToken'],
+                        help='Get specific contract address')
+    
+    args = parser.parse_args()
+    
+    try:
+        result = get_deployment(args.format, args.contract)
+        print(result)
+    except Exception as e:
+        print(f"Error: {e}")
+        exit(1)
+
+# Usage:
+# python get_deployment.py --format json
+# python get_deployment.py --format env > .env
+# python get_deployment.py --contract vendingMachine
+```
+
+### Environment File Generator
+
+```python
+import requests
+import os
+from pathlib import Path
+
+def update_env_file(env_path: str = '.env'):
+    """Update or create .env file with latest deployment addresses."""
+    
+    # Fetch deployment
+    response = requests.get(
+        'https://api.github.com/repos/communetxyz/mutual-vend-sc/releases/latest'
+    )
+    release = response.json()
+    
+    asset = next(
+        (a for a in release['assets'] if a['name'] == 'deployment-gnosis.json'),
+        None
+    )
+    
+    if not asset:
+        raise ValueError('Deployment not found')
+    
+    deployment = requests.get(asset['browser_download_url']).json()
+    
+    # Read existing env file if exists
+    env_vars = {}
+    if Path(env_path).exists():
+        with open(env_path, 'r') as f:
+            for line in f:
+                if '=' in line and not line.startswith('#'):
+                    key, value = line.strip().split('=', 1)
+                    env_vars[key] = value
+    
+    # Update deployment-related variables
+    env_vars.update({
+        'VENDING_MACHINE_ADDRESS': deployment['contracts']['vendingMachine'],
+        'VOTE_TOKEN_ADDRESS': deployment['contracts']['voteToken'],
+        'GNOSIS_RPC_URL': deployment['metadata']['rpcUrl'],
+        'GNOSIS_CHAIN_ID': str(deployment['chainId']),
+        'DEPLOYMENT_VERSION': deployment['version'],
+        'DEPLOYMENT_TIMESTAMP': deployment['metadata']['timestamp']
+    })
+    
+    # Write back to file
+    with open(env_path, 'w') as f:
+        f.write('# Auto-generated Gnosis deployment configuration\n')
+        for key, value in env_vars.items():
+            f.write(f'{key}={value}\n')
+    
+    print(f"✅ Updated {env_path} with latest deployment")
+    return env_vars
+
+# Usage
+env_vars = update_env_file()
+print(f"VendingMachine: {env_vars['VENDING_MACHINE_ADDRESS']}")
+```
+
 ## Notes
 
 - The deployment artifact is created on every deployment to Gnosis Chain

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -1,0 +1,285 @@
+# Frontend Integration Guide
+
+## Fetching Latest Deployment Addresses
+
+The deployment workflow automatically creates a `deployment-gnosis.json` artifact that contains all the necessary information for frontend integration.
+
+### Method 1: Direct GitHub API
+
+Fetch the latest release and download the deployment artifact:
+
+```javascript
+// Fetch latest deployment addresses from GitHub
+async function getLatestDeployment() {
+  try {
+    // Get latest release
+    const releaseResponse = await fetch(
+      'https://api.github.com/repos/communetxyz/mutual-vend-sc/releases/latest'
+    );
+    const release = await releaseResponse.json();
+    
+    // Find the deployment artifact
+    const deploymentAsset = release.assets.find(
+      asset => asset.name === 'deployment-gnosis.json'
+    );
+    
+    if (!deploymentAsset) {
+      throw new Error('Deployment artifact not found');
+    }
+    
+    // Download the deployment artifact
+    const artifactResponse = await fetch(deploymentAsset.browser_download_url);
+    const deployment = await artifactResponse.json();
+    
+    return deployment;
+  } catch (error) {
+    console.error('Failed to fetch deployment:', error);
+    throw error;
+  }
+}
+
+// Usage
+const deployment = await getLatestDeployment();
+console.log('VendingMachine address:', deployment.contracts.vendingMachine);
+console.log('VoteToken address:', deployment.contracts.voteToken);
+console.log('Chain ID:', deployment.chainId);
+console.log('RPC URL:', deployment.metadata.rpcUrl);
+```
+
+### Method 2: Using GitHub Actions API
+
+Fetch from the latest successful workflow run:
+
+```javascript
+async function getDeploymentFromWorkflow() {
+  // Get latest successful workflow run
+  const workflowResponse = await fetch(
+    'https://api.github.com/repos/communetxyz/mutual-vend-sc/actions/workflows/deploy-gnosis.yml/runs?status=success&per_page=1'
+  );
+  const { workflow_runs } = await workflowResponse.json();
+  
+  if (!workflow_runs.length) {
+    throw new Error('No successful deployments found');
+  }
+  
+  const latestRun = workflow_runs[0];
+  
+  // Get artifacts from the workflow run
+  const artifactsResponse = await fetch(latestRun.artifacts_url);
+  const { artifacts } = await artifactsResponse.json();
+  
+  const deploymentArtifact = artifacts.find(
+    a => a.name.startsWith('deployment-gnosis-')
+  );
+  
+  // Note: Downloading artifacts requires authentication
+  // For public access, use Method 1 (releases) instead
+  return deploymentArtifact;
+}
+```
+
+### Method 3: Static CDN (Recommended for Production)
+
+Host the deployment artifact on a CDN that auto-updates from GitHub releases:
+
+```javascript
+// Using jsDelivr CDN (auto-updates from GitHub)
+async function getDeploymentFromCDN() {
+  const response = await fetch(
+    'https://cdn.jsdelivr.net/gh/communetxyz/mutual-vend-sc@latest/deployment-gnosis.json'
+  );
+  return await response.json();
+}
+```
+
+## Deployment Artifact Structure
+
+The `deployment-gnosis.json` file contains:
+
+```typescript
+interface DeploymentArtifact {
+  network: 'gnosis';
+  chainId: 100;
+  contracts: {
+    vendingMachine: string;  // Contract address
+    voteToken: string;       // Token contract address
+  };
+  transactions: {
+    deployment: string;      // Deployment transaction hash
+    testPurchase?: string;   // Test purchase transaction hash
+  };
+  metadata: {
+    timestamp: string;       // ISO 8601 timestamp
+    commitHash: string;      // Git commit hash
+    deployer: string;        // Deployer address
+    rpcUrl: string;          // Recommended RPC endpoint
+    explorerUrl: string;     // Block explorer URL
+    acceptedTokens: string[]; // Array of accepted token addresses
+  };
+  version: string;           // Release version or build number
+  abi: {
+    vendingMachine: string;  // URL to interface file
+  };
+}
+```
+
+## React Hook Example
+
+```jsx
+import { useState, useEffect } from 'react';
+
+function useVendingMachineContract() {
+  const [deployment, setDeployment] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    async function fetchDeployment() {
+      try {
+        const response = await fetch(
+          'https://api.github.com/repos/communetxyz/mutual-vend-sc/releases/latest'
+        );
+        const release = await response.json();
+        
+        const asset = release.assets.find(a => a.name === 'deployment-gnosis.json');
+        if (!asset) throw new Error('Deployment not found');
+        
+        const deploymentResponse = await fetch(asset.browser_download_url);
+        const deploymentData = await deploymentResponse.json();
+        
+        setDeployment(deploymentData);
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchDeployment();
+  }, []);
+
+  return { deployment, loading, error };
+}
+
+// Usage in component
+function VendingMachineApp() {
+  const { deployment, loading, error } = useVendingMachineContract();
+
+  if (loading) return <div>Loading contract addresses...</div>;
+  if (error) return <div>Error: {error}</div>;
+
+  return (
+    <div>
+      <h1>Vending Machine</h1>
+      <p>Contract: {deployment.contracts.vendingMachine}</p>
+      <p>Network: {deployment.network} (Chain {deployment.chainId})</p>
+      <a 
+        href={`${deployment.metadata.explorerUrl}/address/${deployment.contracts.vendingMachine}`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        View on Explorer
+      </a>
+    </div>
+  );
+}
+```
+
+## Ethers.js Integration
+
+```javascript
+import { ethers } from 'ethers';
+
+async function connectToVendingMachine() {
+  // Fetch deployment info
+  const deployment = await getLatestDeployment();
+  
+  // Connect to Gnosis
+  const provider = new ethers.JsonRpcProvider(deployment.metadata.rpcUrl);
+  
+  // Load ABI (you'll need to fetch this separately)
+  const abi = await fetchVendingMachineABI();
+  
+  // Create contract instance
+  const vendingMachine = new ethers.Contract(
+    deployment.contracts.vendingMachine,
+    abi,
+    provider
+  );
+  
+  // For write operations, connect signer
+  const signer = await provider.getSigner();
+  const vendingMachineWithSigner = vendingMachine.connect(signer);
+  
+  return vendingMachineWithSigner;
+}
+```
+
+## Viem Integration
+
+```javascript
+import { createPublicClient, http } from 'viem';
+import { gnosis } from 'viem/chains';
+
+async function setupViem() {
+  const deployment = await getLatestDeployment();
+  
+  const client = createPublicClient({
+    chain: gnosis,
+    transport: http(deployment.metadata.rpcUrl),
+  });
+  
+  // Read from contract
+  const result = await client.readContract({
+    address: deployment.contracts.vendingMachine,
+    abi: vendingMachineABI,
+    functionName: 'getTrack',
+    args: [0],
+  });
+  
+  return result;
+}
+```
+
+## Environment Variables
+
+For local development, create a `.env` file:
+
+```bash
+# Fetched dynamically from deployment artifact
+NEXT_PUBLIC_VENDING_MACHINE_ADDRESS=
+NEXT_PUBLIC_VOTE_TOKEN_ADDRESS=
+NEXT_PUBLIC_GNOSIS_RPC_URL=https://rpc.gnosischain.com
+NEXT_PUBLIC_CHAIN_ID=100
+```
+
+Then use a script to update from the latest deployment:
+
+```javascript
+// scripts/update-env.js
+const fs = require('fs');
+
+async function updateEnv() {
+  const deployment = await getLatestDeployment();
+  
+  const envContent = `
+NEXT_PUBLIC_VENDING_MACHINE_ADDRESS=${deployment.contracts.vendingMachine}
+NEXT_PUBLIC_VOTE_TOKEN_ADDRESS=${deployment.contracts.voteToken}
+NEXT_PUBLIC_GNOSIS_RPC_URL=${deployment.metadata.rpcUrl}
+NEXT_PUBLIC_CHAIN_ID=${deployment.chainId}
+`;
+  
+  fs.writeFileSync('.env.local', envContent.trim());
+  console.log('✅ Environment variables updated');
+}
+
+updateEnv();
+```
+
+## Notes
+
+- The deployment artifact is created on every deployment to Gnosis Chain
+- For production, use releases (tagged versions) rather than PR deployments
+- The artifact includes all necessary metadata for frontend integration
+- Consider caching the deployment data to reduce API calls
+- Always verify the chain ID before interacting with contracts

--- a/config/gnosis.json
+++ b/config/gnosis.json
@@ -1,0 +1,43 @@
+{
+  "numTracks": 5,
+  "maxStockPerTrack": 10,
+  "tokenName": "Vending Machine Token",
+  "tokenSymbol": "VMT",
+  "acceptedTokens": [
+    "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83",
+    "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d",
+    "0x4ECaBa5870353805a9F068101A40E0f32ed605C6"
+  ],
+  "products": [
+    {
+      "name": "Coca Cola",
+      "ipfsHash": "ipfs://QmCocaCola",
+      "stock": 10,
+      "price": "2000000000000000000"
+    },
+    {
+      "name": "Pepsi",
+      "ipfsHash": "ipfs://QmPepsi",
+      "stock": 10,
+      "price": "2000000000000000000"
+    },
+    {
+      "name": "Water",
+      "ipfsHash": "ipfs://QmWater",
+      "stock": 10,
+      "price": "1000000000000000000"
+    },
+    {
+      "name": "Orange Juice",
+      "ipfsHash": "ipfs://QmOrangeJuice",
+      "stock": 8,
+      "price": "3000000000000000000"
+    },
+    {
+      "name": "Energy Drink",
+      "ipfsHash": "ipfs://QmEnergyDrink",
+      "stock": 5,
+      "price": "4000000000000000000"
+    }
+  ]
+}

--- a/config/gnosis.json
+++ b/config/gnosis.json
@@ -11,19 +11,19 @@
       "name": "Coca Cola",
       "ipfsHash": "ipfs://QmCocaCola",
       "stock": 10,
-      "price": "2000000000000000000"
+      "price": "200000000000000000"
     },
     {
       "name": "Pepsi",
       "ipfsHash": "ipfs://QmPepsi",
       "stock": 10,
-      "price": "2000000000000000000"
+      "price": "200000000000000000"
     },
     {
       "name": "Water",
       "ipfsHash": "ipfs://QmWater",
       "stock": 10,
-      "price": "1000000000000000000"
+      "price": "200000000000000000"
     }
   ]
 }

--- a/config/gnosis.json
+++ b/config/gnosis.json
@@ -1,5 +1,5 @@
 {
-  "numTracks": 5,
+  "numTracks": 3,
   "maxStockPerTrack": 10,
   "tokenName": "Vending Machine Token",
   "tokenSymbol": "VMT",
@@ -24,18 +24,6 @@
       "ipfsHash": "ipfs://QmWater",
       "stock": 10,
       "price": "1000000000000000000"
-    },
-    {
-      "name": "Orange Juice",
-      "ipfsHash": "ipfs://QmOrangeJuice",
-      "stock": 8,
-      "price": "3000000000000000000"
-    },
-    {
-      "name": "Energy Drink",
-      "ipfsHash": "ipfs://QmEnergyDrink",
-      "stock": 5,
-      "price": "4000000000000000000"
     }
   ]
 }

--- a/config/gnosis.json
+++ b/config/gnosis.json
@@ -4,9 +4,7 @@
   "tokenName": "Vending Machine Token",
   "tokenSymbol": "VMT",
   "acceptedTokens": [
-    "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83",
-    "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d",
-    "0x4ECaBa5870353805a9F068101A40E0f32ed605C6"
+    "0xa555d5344f6FB6c65da19e403Cb4c1eC4a1a5Ee3"
   ],
   "products": [
     {

--- a/script/DeployVendingMachine.s.sol
+++ b/script/DeployVendingMachine.s.sol
@@ -127,6 +127,8 @@ contract DeployVendingMachine is Script {
 
     if (block.chainid == 1) {
       configFile = 'mainnet.json';
+    } else if (block.chainid == 100) {
+      configFile = 'gnosis.json';
     } else if (block.chainid == 17_000) {
       configFile = 'holesky.json';
     } else if (block.chainid == 11_155_111) {

--- a/script/PurchaseFromGnosis.s.sol
+++ b/script/PurchaseFromGnosis.s.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {VendingMachine} from '../src/contracts/VendingMachine.sol';
+import {IVendingMachine} from '../src/interfaces/IVendingMachine.sol';
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import {Script, console2} from 'forge-std/Script.sol';
+
+contract PurchaseFromGnosis is Script {
+  // Gnosis token address from config
+  address constant GNOSIS_TOKEN = 0xa555d5344f6FB6c65da19e403Cb4c1eC4a1a5Ee3;
+
+  function run() external {
+    // Get environment variables
+    uint256 deployerPrivateKey = vm.envUint('PRIVATE_KEY');
+    address deployer = vm.addr(deployerPrivateKey);
+
+    // Get the VendingMachine address from environment or use a default
+    address vendingMachineAddress =
+      vm.envOr('VENDING_MACHINE_ADDRESS', address(0x914b0Ac88384A9Ccb7D0d61d35e5EDee60860900));
+
+    console2.log('===========================================');
+    console2.log('Purchasing from VendingMachine on Gnosis');
+    console2.log('===========================================');
+    console2.log('Purchaser:', deployer);
+    console2.log('VendingMachine:', vendingMachineAddress);
+    console2.log('Token:', GNOSIS_TOKEN);
+
+    vm.startBroadcast(deployerPrivateKey);
+
+    // Get references to contracts
+    IERC20 token = IERC20(GNOSIS_TOKEN);
+    VendingMachine vendingMachine = VendingMachine(vendingMachineAddress);
+
+    // Check token balance
+    uint256 tokenBalance = token.balanceOf(deployer);
+    console2.log('Token Balance:', tokenBalance);
+
+    if (tokenBalance == 0) {
+      console2.log('Warning: No token balance');
+    }
+
+    // Get track information for all 3 tracks
+    for (uint8 trackId = 0; trackId < 3; trackId++) {
+      IVendingMachine.Track memory track = vendingMachine.getTrack(trackId);
+
+      console2.log('===========================================');
+      console2.log('Track', trackId, 'Information:');
+      console2.log('Product:', track.product.name);
+      console2.log('Stock:', track.stock);
+      console2.log('Price:', track.price);
+    }
+
+    // Purchase from track 0 (Coca Cola)
+    uint8 trackToPurchase = 0;
+    IVendingMachine.Track memory selectedTrack = vendingMachine.getTrack(trackToPurchase);
+
+    console2.log('===========================================');
+    console2.log('Attempting to purchase from Track', trackToPurchase);
+    console2.log('Product:', selectedTrack.product.name);
+    console2.log('Price:', selectedTrack.price);
+
+    if (selectedTrack.stock == 0) {
+      console2.log('Track is out of stock!');
+      vm.stopBroadcast();
+      return;
+    }
+
+    if (tokenBalance < selectedTrack.price) {
+      console2.log('Insufficient token balance for purchase');
+      console2.log('Required:', selectedTrack.price);
+      console2.log('Available:', tokenBalance);
+      vm.stopBroadcast();
+      return;
+    }
+
+    // Check current allowance
+    uint256 currentAllowance = token.allowance(deployer, vendingMachineAddress);
+    console2.log('Current token allowance:', currentAllowance);
+
+    // Approve VendingMachine to spend tokens if needed
+    if (currentAllowance < selectedTrack.price) {
+      console2.log('Approving VendingMachine to spend', selectedTrack.price, 'tokens...');
+      bool approveSuccess = token.approve(vendingMachineAddress, selectedTrack.price);
+      require(approveSuccess, 'Token approval failed');
+      console2.log('Approval successful!');
+    } else {
+      console2.log('Sufficient allowance already exists');
+    }
+
+    // Make the purchase
+    console2.log('Purchasing from track', trackToPurchase, '...');
+    vendingMachine.vendFromTrack(trackToPurchase, GNOSIS_TOKEN, deployer);
+    console2.log('Purchase successful!');
+
+    // Check new balance and vote tokens received
+    uint256 newTokenBalance = token.balanceOf(deployer);
+    console2.log('New Token Balance:', newTokenBalance);
+    console2.log('Tokens Spent:', tokenBalance - newTokenBalance);
+
+    // Get vote token balance
+    address voteTokenAddress = address(vendingMachine.voteToken());
+    IERC20 voteToken = IERC20(voteTokenAddress);
+    uint256 voteTokenBalance = voteToken.balanceOf(deployer);
+    console2.log('Vote Tokens Received:', voteTokenBalance);
+
+    vm.stopBroadcast();
+
+    console2.log('===========================================');
+    console2.log('Purchase completed successfully!');
+    console2.log('===========================================');
+  }
+}

--- a/script/PurchaseFromGnosis.s.sol
+++ b/script/PurchaseFromGnosis.s.sol
@@ -63,7 +63,7 @@ contract PurchaseFromGnosis is Script {
     if (selectedTrack.stock == 0) {
       console2.log('Track is out of stock!');
       vm.stopBroadcast();
-      return;
+      revert('Track is out of stock');
     }
 
     if (tokenBalance < selectedTrack.price) {
@@ -71,7 +71,7 @@ contract PurchaseFromGnosis is Script {
       console2.log('Required:', selectedTrack.price);
       console2.log('Available:', tokenBalance);
       vm.stopBroadcast();
-      return;
+      revert('Insufficient token balance for purchase');
     }
 
     // Check current allowance


### PR DESCRIPTION
## Summary
- Added GitHub Actions workflow for Gnosis Chain deployment
- Created Gnosis Chain configuration with appropriate mainnet token addresses
- Updated deployment script to recognize Gnosis Chain (chain ID 100)

## Changes
- **New workflow**: `.github/workflows/deploy-gnosis.yml` - Deploys contracts to Gnosis Chain on PR, push to main, and release events
- **New config**: `config/gnosis.json` - Contains Gnosis-specific deployment parameters including USDC, WXDAI, and USDT addresses
- **Updated script**: Modified `DeployVendingMachine.s.sol` to support Gnosis Chain

## Environment Variables Required
The following secrets need to be added to the repository:
- `MAINNET_DEPLOYER_PRIVATE_KEY` - Private key for mainnet deployments
- `MAINNET_DEPLOYER_ADDRESS` - Address of the mainnet deployer
- `GNOSIS_RPC_URL` - RPC endpoint for Gnosis Chain
- `GNOSISSCAN_API_KEY` - API key for contract verification on Gnosisscan

## Test Plan
- [ ] Verify workflow syntax is correct
- [ ] Test deployment on pull request (currently enabled for testing)
- [ ] Confirm contract verification works on Gnosisscan
- [ ] Test release trigger deployment

🤖 Generated with [Claude Code](https://claude.ai/code)