### PR TITLE
fix: grant write permissions for release creation in gnosis deployment workflow

### DIFF
--- a/.github/workflows/deploy-gnosis.yml
+++ b/.github/workflows/deploy-gnosis.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: gnosis-mainnet
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     
     steps:


### PR DESCRIPTION
## Summary
- Fixed GitHub Actions permission issue that was preventing release creation in the Gnosis deployment workflow
- Changed `contents` permission from `read` to `write` to allow the workflow to create GitHub releases

## Problem
The Gnosis Chain deployment workflow was failing with a **403 "Resource not accessible by integration"** error when attempting to create releases after successful deployment. The deployment and contract verification completed successfully, but the final release creation step failed.

## Solution
Updated the workflow permissions in `.github/workflows/deploy-gnosis.yml`:
- Changed `contents: read` to `contents: write`
- This grants the necessary permissions for:
  - Creating releases via `github.rest.repos.createRelease`
  - Uploading release assets
  - Updating release descriptions

## Testing
The workflow will be tested on the next push to main or manual workflow dispatch. The fix specifically addresses the error seen in [workflow run #17709579341](https://github.com/communetxyz/mutual-vend-sc/actions/runs/17709579341).

## Related Issues
- Fixes the release creation failure in Gnosis deployment workflow

🤖 Generated with [Claude Code](https://claude.ai/code)