### PR TITLE
Update Gnosis vending machine product catalog

### DIFF
--- a/config/gnosis.json
+++ b/config/gnosis.json
@@ -8,22 +8,22 @@
   ],
   "products": [
     {
-      "name": "Coca Cola",
-      "ipfsHash": "ipfs://QmCocaCola",
-      "stock": 10,
-      "price": "200000000000000000"
+      "name": "Protein Bars and Beef Jerky",
+      "ipfsHash": "https://ava.com.sa/sys/storage/uploads/is_cover_image/PXL_20250914_125533552_1757855386.jpg",
+      "stock": 6,
+      "price": "1500000000000000000"
     },
     {
-      "name": "Pepsi",
-      "ipfsHash": "ipfs://QmPepsi",
-      "stock": 10,
-      "price": "200000000000000000"
+      "name": "Milano Cookies and Oreos",
+      "ipfsHash": "https://ava.com.sa/sys/storage/uploads/is_cover_image/PXL_20250914_125350628_1757855467.jpg",
+      "stock": 7,
+      "price": "1500000000000000000"
     },
     {
-      "name": "Water",
-      "ipfsHash": "ipfs://QmWater",
-      "stock": 10,
-      "price": "200000000000000000"
+      "name": "5$ Crypto Vending Machine Wallets",
+      "ipfsHash": "https://ava.com.sa/sys/storage/uploads/is_cover_image/PXL_20250914_125325408%20(1)_1757855751.jpg",
+      "stock": 4,
+      "price": "5000000000000000000"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Updated Gnosis configuration to replace demo products with actual vending machine items
- Added real product photos and appropriate pricing for physical vending machine

## Changes
- **Protein Bars and Beef Jerky**: $1.50, stock: 6 units
- **Milano Cookies and Oreos**: $1.50, stock: 7 units
- **5$ Crypto Vending Machine Wallets**: $5.00, stock: 4 units

## Test plan
- [ ] Deploy to Gnosis testnet
- [ ] Verify products display correctly with images
- [ ] Test purchase flow for each product
- [ ] Confirm stock levels are accurate

🤖 Generated with [Claude Code](https://claude.ai/code)