### PR TITLE
feat: Configurable Revenue Distribution for TreasuryDistributor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ broadcast/*/*/*
 # Out dir
 out
 crytic-export
+crowdstake.fun/

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ broadcast/*/*/*
 # Out dir
 out
 crytic-export
-crowdstake.fun/

--- a/MULTI_STOCKER_DESIGN.md
+++ b/MULTI_STOCKER_DESIGN.md
@@ -1,0 +1,90 @@
+# Multi-Stocker Revenue Sharing Design
+
+## Overview
+This document describes the multi-stocker revenue sharing implementation that allows different products in the vending machine to have different stockers, each receiving their own configured share of revenue.
+
+## Problem Statement
+The vending machine needs to support a marketplace model where different vendors (stockers) can stock different products, each receiving their configured share of the revenue from their specific products.
+
+## Current Implementation
+
+### Key Features
+1. **Per-Product Stocker Addresses**: Each product in the vending machine has its own designated stocker who receives the revenue share.
+2. **Per-Product Revenue Shares**: Each product maintains its own `stockerShareBps` (basis points) for flexible revenue distribution.
+3. **Dynamic Stocker Assignment**: When an operator restocks a track, they become the new stocker for that track and can set their revenue share.
+4. **Multiple Stockers Tracking**: The TreasuryDistributor tracks multiple stockers efficiently using:
+   - `stockerRevenue[stocker][token]` mapping for per-stocker, per-token revenue
+   - `stockersWithRevenue` array to track active stockers in the current cycle
+   - `hasStockerRevenue` mapping to prevent duplicate entries
+
+### Data Structures
+
+#### Updated Product Struct in VendingMachine
+```solidity
+struct Product {
+    string name;
+    string imageURI;
+    uint256 stockerShareBps;  // stocker's revenue share in basis points (e.g., 2000 = 20%)
+    address stockerAddress;   // address that receives stocker share for this product
+}
+```
+
+#### TreasuryDistributor Storage
+```solidity
+address[] public stockersWithRevenue;                             // array of stockers with revenue in current cycle
+mapping(address => mapping(address => uint256)) public stockerRevenue;  // stocker => token => amount
+mapping(address => bool) public hasStockerRevenue;                // stocker => has revenue in current cycle
+```
+
+### Flow
+1. **Product Configuration**: When a product is set (deployment or `loadTrack`), stocker address and share are configured.
+2. **Restocking**: When `restockTrack` is called:
+   - The caller becomes the new stocker for that track
+   - They can set their desired revenue share percentage
+   - Events are emitted for stocker changes
+3. **Purchase**: During `vendFromTrack`, the VendingMachine:
+   - Accepts payment and mints vote tokens
+   - Calls `TreasuryDistributor.onPurchase()` with product's stocker info
+4. **Distribution**: Each stocker receives their accumulated revenue across all their products
+
+### Implementation Changes
+
+#### VendingMachine Contract
+- Product struct includes `stockerAddress` field
+- Constructor validates stocker addresses are not zero
+- `_loadTrack` validates stocker configuration
+- `restockTrack` updates stocker to msg.sender and allows setting revenue share
+- `vendFromTrack` passes stocker info to TreasuryDistributor
+
+#### TreasuryDistributor Contract
+- Tracks revenue per stocker per token
+- `onPurchase` accepts stocker address parameter
+- Distribution iterates through all stockers with revenue
+- Reset functions clear stocker-specific data
+
+#### Interfaces
+- `ITreasuryDistributor.onPurchase()` includes stocker address parameter
+- `IVendingMachine.Product` includes stocker fields
+- New events: `StockerChanged`, updated `TrackRestocked`
+
+### Benefits
+1. **Marketplace Model**: Supports multiple vendors in the same vending machine
+2. **Flexible Revenue**: Each product can have different revenue sharing terms
+3. **Incentivized Restocking**: Operators who restock become stockers and earn revenue
+4. **Transparent Tracking**: Clear visibility of who earns what from each product
+
+### Complexity Considerations
+1. **Gas Costs**: Iterating through multiple stockers during distribution
+2. **State Management**: More complex tracking of stocker revenues
+3. **Testing**: Need to verify stocker changes and multi-stocker distributions
+4. **Initialization**: TreasuryDistributor uses initializer pattern for upgradability
+
+## Alternative: Simple Single-Stocker Design
+A simpler alternative would be:
+- Single stocker address for the entire vending machine
+- Single revenue share percentage applied to all products
+- No stocker changes on restocking
+- Simpler distribution logic with lower gas costs
+
+## Decision
+After implementation and review, the decision was made to revert to the simpler single-stocker design to reduce complexity and gas costs while maintaining the core revenue sharing functionality.

--- a/REVENUE_SHARING_ISSUE.md
+++ b/REVENUE_SHARING_ISSUE.md
@@ -1,0 +1,106 @@
+# Feature: Implement Revenue Sharing for Vote Token Holders
+
+## Summary
+Implement an autonomous revenue sharing system that distributes monthly dividends from vending machine sales to vote token holders proportionally to their holdings.
+
+## Problem
+The vending machine generates revenue from product sales but lacks a mechanism to distribute profits to vote token holders. Revenue accumulates in the VendingMachine contract with no automated distribution system.
+
+## Proposed Solution
+
+### Core Architecture
+- **TreasuryDistributor Contract**: Autonomous contract with TREASURY_ROLE that manages monthly distributions
+- **Revenue Split**: Stocker receives fixed percentage (e.g., 20%), remainder distributed to consumers
+- **Purchase-Time Tracking**: Track buyer eligibility during vending machine purchases
+- **Time-Based Cycles**: 30-day distribution cycles using block.timestamp
+- **Push-Based Distribution**: Automatic transfer of dividends without user action
+- **Multi-Token Support**: Distribute USDC, USDT, DAI proportionally
+
+### Key Components
+
+#### 1. Data Structures
+```solidity
+address[] public currentBuyers;                          // buyers in current cycle
+mapping(address => uint256) public eligibleBalance;      // balance - lastIncludedBalance
+mapping(address => uint256) public lastIncludedBalance;  // balance included in last distribution
+mapping(address => bool) public isInCurrentCycle;        // track if buyer in current cycle
+address public stockerAddress;                          // address receiving stocker share
+uint256 public stockerShareBps = 2000;                  // 20% for stocker
+uint256 public cycleLength = 30 days;                   // distribution interval
+uint256 public lastCycleTimestamp;                      // when current cycle started
+```
+
+#### 2. Distribution Flow
+1. **Purchase Hook**: VendingMachine notifies TreasuryDistributor on each sale
+2. **Track Eligibility**: Calculate `eligibleBalance = currentBalance - lastIncludedBalance`
+3. **Monthly Distribution**:
+   - Claim all token balances from VendingMachine
+   - Pay stocker share: `totalRevenue * stockerShareBps / 10000`
+   - Distribute remainder to consumers: `(eligibleBalance / totalEligible) * consumerRevenue`
+   - Transfer proportional amounts of each token
+   - Update lastIncludedBalance and clear mappings
+   - Reset for new cycle
+
+#### 3. Integration Requirements
+- **VendingMachine**: Add `_notifyTreasuryOnPurchase()` hook after minting
+- **VoteToken**: No changes needed - uses standard ERC20Votes interface
+- **Access Control**: Grant TREASURY_ROLE to TreasuryDistributor
+
+## Benefits
+- **Gas Efficient**: Only iterate active buyers, not all token holders
+- **Fair Distribution**: Based on holdings minus already distributed amounts
+- **Autonomous**: No manual intervention required
+- **Sybil Resistant**: Physical vending constraints prevent gaming
+
+## Implementation Tasks
+
+### Smart Contracts
+- [ ] Create TreasuryDistributor contract
+- [ ] Add purchase hook to VendingMachine
+- [ ] Implement cycle management logic
+- [ ] Add multi-token distribution support
+
+### Testing
+- [ ] Unit tests for distribution calculations
+- [ ] Integration tests with VendingMachine
+- [ ] Gas consumption benchmarks
+- [ ] Multi-cycle accuracy tests
+
+### Deployment
+- [ ] Deploy TreasuryDistributor
+- [ ] Grant TREASURY_ROLE to distributor
+- [ ] Configure allowed tokens list
+- [ ] Initialize first cycle
+
+## Acceptance Criteria
+- [ ] Monthly distributions execute automatically
+- [ ] Stocker receives configured percentage (e.g., 20%) of revenue
+- [ ] Remaining revenue distributed proportionally to vote token holders
+- [ ] Multiple payment tokens distributed correctly
+- [ ] Gas costs remain reasonable for up to 1000 buyers
+- [ ] No manual intervention required after deployment
+
+## Technical Specifications
+See [REVENUE_SHARING_SPEC.md](./docs/REVENUE_SHARING_SPEC.md) for detailed architecture and implementation details.
+
+## Estimated Effort
+- Development: 2-3 weeks
+- Testing: 1 week
+- Deployment & Verification: 2-3 days
+
+## Dependencies
+- Existing VendingMachine contract
+- Existing VoteToken (ERC20Votes)
+- Access to TREASURY_ROLE for configuration
+
+## Risks & Mitigations
+- **Risk**: High gas costs with many buyers
+  - **Mitigation**: Batch processing, only track active participants
+- **Risk**: Failed token transfers blocking distribution
+  - **Mitigation**: Continue distribution even if individual transfers fail
+- **Risk**: Time manipulation
+  - **Mitigation**: Use reasonable time windows, require minimum cycle length
+
+## References
+- [Technical Specification](./docs/REVENUE_SHARING_SPEC.md)
+- [Crowdstake.fun Cycle Management](./crowdstake.fun/src/CycleModule.sol) (inspiration)

--- a/docs/REVENUE_SHARING_SPEC.md
+++ b/docs/REVENUE_SHARING_SPEC.md
@@ -1,0 +1,359 @@
+# Revenue Sharing & Dividend Distribution Technical Specification
+
+## 1. Background
+
+### Problem Statement
+The vending machine generates revenue from product sales but lacks a mechanism to distribute profits to vote token holders proportionally to their holdings.
+
+### Context / History
+- Current system: VendingMachine.sol accepts stablecoin payments and mints VoteTokens to purchasers
+- VoteToken implements ERC20Votes for governance capabilities
+- Treasury can withdraw revenue but no automated distribution exists
+- Permissioned roles: OPERATOR_ROLE, TREASURY_ROLE, DEFAULT_ADMIN_ROLE
+- Each product can have different stockers and revenue share percentages
+
+### Stakeholders
+- Vote token holders (automatically receive dividends)
+- Treasury contract (manages distributions via delegated role)
+- Vending machine operators (maintain revenue flow)
+- Product stockers (receive revenue share per product they stock)
+
+## 2. Motivation
+
+### Goals & Success Stories
+- Enable periodic dividend distributions to vote token holders (configurable cycle length)
+- Decentralize revenue share controls using existing role system delegated to contracts
+- Automatic push-based distribution to all token holders
+- Support multiple payment tokens (USDC, USDT, DAI)
+- Gas-efficient distribution through purchase-time tracking and cycle-based arrays
+- Flexible distribution schedules (weekly, bi-weekly, monthly, etc.)
+
+## 3. Scope and Approaches
+
+### Value Proposition
+
+| Technical Functionality | Value | Tradeoffs |
+|------------------------|-------|-----------|
+| Push-based distribution | Automatic monthly payouts to all holders | Higher gas costs for distributor |
+| Purchase-time tracking | Buyer eligibility tracked during vending | Minimal computation at distribution |
+| Cycle-based buyer arrays | Efficient iteration of eligible recipients | Storage for buyer list per cycle |
+| Balance snapshot mapping | Track (balance - cumulative) per cycle | Clean separation of cycles |
+| Contract-based treasury | Decentralized control via smart contracts | Requires careful role delegation |
+
+### Non-Goals
+- Historical tracking onchain (offscope)
+- Pull-based claiming mechanisms
+- Governance voting on distribution amounts
+- Tax reporting features
+- Manual claim processes
+
+## 4. Step-by-Step Flow
+
+### 4.1 Main ("Happy") Path
+
+**Periodic Distribution Process:**
+
+1. **Pre-condition**: Revenue accumulated and pre-split in TreasuryDistributor, cycle complete
+2. **Treasury Contract** detects cycle completion (time-based: `block.timestamp >= lastCycleTimestamp + cycleLength`)
+3. **Distribute stocker revenue**:
+   - For each stocker with revenue this cycle:
+     - For each token in `allowedTokens`:
+       - Transfer `stockerRevenue[stocker][token]` to stocker address
+4. **System** iterates through `currentBuyers` array
+5. **For each buyer**: 
+   - Calculate share percentage = `eligibleBalance[buyer] / totalEligible`
+   - For each token:
+     - Transfer `consumerRevenue[token] * sharePercentage` to buyer
+   - Update: `lastIncludedBalance[buyer] = voteToken.balanceOf(buyer)`
+   - Delete: `eligibleBalance[buyer]` and `isInCurrentCycle[buyer]`
+6. **System** resets for new cycle:
+   - Clear `currentBuyers` array
+   - Reset `totalEligible = 0`
+   - Reset all `stockerRevenue[token] = 0` and `consumerRevenue[token] = 0`
+7. **Post-condition**: All dividends distributed, new cycle begins
+
+### 4.2 Purchase-Time Tracking System
+
+**On Each VendingMachine Purchase:**
+1. **VendingMachine** mints VoteTokens to buyer (standard ERC20Votes)
+2. **VendingMachine** calls purchase hook on TreasuryDistributor with:
+   - Buyer address
+   - Payment token used
+   - Payment amount
+   - Product's `stockerShareBps`
+   - Product's `stockerAddress`
+3. **If not in current cycle**: 
+   - Add buyer to `currentBuyers` array
+   - Set `isInCurrentCycle[buyer] = true`
+4. **TreasuryDistributor** queries `voteToken.balanceOf(buyer)` for current balance
+5. **Calculate new eligible**: `newEligible = balance - lastIncludedBalance[buyer]`
+6. **Update totals**:
+   - `totalEligible = totalEligible - eligibleBalance[buyer] + newEligible`
+   - `eligibleBalance[buyer] = newEligible`
+7. **Split and track revenue**:
+   - `stockerAmount = paymentAmount * stockerShareBps / 10000`
+   - `consumerAmount = paymentAmount - stockerAmount`
+   - `stockerRevenue[stockerAddress][token] += stockerAmount`
+   - Track stocker in `stockersWithRevenue` array if new
+   - `consumerRevenue[token] += consumerAmount`
+
+Note: Revenue is pre-split at purchase time based on product configuration
+
+### 4.4 Alternate / Error Paths
+
+| # | Condition | System Action | Suggested Handling |
+|---|-----------|---------------|-------------------|
+| A1 | No revenue in cycle | Skip distribution | Start new cycle immediately |
+| A2 | User eligible balance is zero | Skip user in distribution | No transfer needed |
+| A3 | Failed transfer to holder | Log failure event | Continue with other holders |
+| A4 | Cycle not complete | Reject distribution attempt | Wait for cycle completion |
+
+## 5. Architecture Diagrams
+
+### Class Diagram
+
+```mermaid
+classDiagram
+    class TreasuryDistributor {
+        +address[] currentBuyers
+        +address[] allowedTokens
+        +mapping(address => uint256) eligibleBalance
+        +mapping(address => uint256) lastIncludedBalance
+        +mapping(address => bool) isInCurrentCycle
+        +uint256 totalEligible
+        +uint256 currentCycle
+        +uint256 cycleLength
+        +uint256 lastCycleTimestamp
+        +distributeMonthlyRevenue()
+        +claimRevenueFromVending()
+        +onPurchase(buyer)
+        +startNewCycle()
+        +isCycleComplete()
+    }
+    
+    class VoteToken {
+        <<interface IVotes>>
+        +balanceOf(account)
+        +totalSupply()
+        +delegate(delegatee)
+        +getPastVotes(account, blockNumber)
+        +getPastTotalSupply(blockNumber)
+    }
+    
+    class VendingMachine {
+        +vendFromTrack()
+        +mint(to, amount)
+        +_notifyTreasuryOnPurchase()
+        +TREASURY_ROLE
+    }
+    
+    class CycleModule {
+        +cycleLength
+        +currentCycle
+        +lastCycleTimestamp
+        +isCycleComplete()
+        +startNewCycle()
+    }
+    
+    VendingMachine --> VoteToken : mints tokens
+    VendingMachine --> TreasuryDistributor : calls purchase hook
+    TreasuryDistributor --> VoteToken : queries balances
+    TreasuryDistributor --> CycleModule : uses cycle timing
+    TreasuryDistributor --> Holders : pushes dividends
+```
+
+### Contract Initialization
+
+```solidity
+// TreasuryDistributor constructor/initializer parameters
+constructor(
+    address _voteToken,
+    address _vendingMachine,
+    address[] memory _allowedTokens,
+    uint256 _cycleLength        // Common values:
+                               // 1 day: 86,400 seconds
+                               // 1 week: 604,800 seconds  
+                               // 2 weeks: 1,209,600 seconds
+                               // 30 days: 2,592,000 seconds
+                               // 90 days: 7,776,000 seconds
+) {
+    voteToken = IVoteToken(_voteToken);
+    vendingMachine = IVendingMachine(_vendingMachine);
+    allowedTokens = _allowedTokens;
+    cycleLength = _cycleLength;
+    lastCycleTimestamp = block.timestamp;
+    currentCycle = 1;
+}
+```
+
+### Data Structure Design
+
+```solidity
+// Updated Product struct in VendingMachine
+struct Product {
+    string name;
+    string imageURI;
+    uint256 stockerShareBps;                            // stocker's revenue share for this product (e.g., 2000 = 20%)
+    address stockerAddress;                              // address that receives stocker share for this product
+}
+
+// TreasuryDistributor storage
+address[] public currentBuyers;                                   // array of buyers for current cycle
+address[] public stockersWithRevenue;                             // array of stockers with revenue in current cycle
+mapping(address => uint256) public eligibleBalance;               // buyer => (balance - lastIncludedBalance)
+mapping(address => uint256) public lastIncludedBalance;           // buyer => balance included in last distribution
+mapping(address => bool) public isInCurrentCycle;                 // buyer => in current cycle array
+
+address[] public allowedTokens;                                   // list of payment tokens (USDC, USDT, DAI)
+mapping(address => mapping(address => uint256)) public stockerRevenue;  // stocker => token => amount
+mapping(address => uint256) public consumerRevenue;               // token => consumer revenue accumulated in cycle
+mapping(address => bool) public hasStockerRevenue;                // stocker => has revenue in current cycle
+uint256 public totalEligible;                                     // sum of all eligible balances
+uint256 public currentCycle;
+uint256 public immutable cycleLength;                             // cycle duration in seconds (set at initialization)
+uint256 public lastCycleTimestamp;                                // timestamp when current cycle started
+```
+
+### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant VendingMachine
+    participant TreasuryDistributor
+    participant VoteToken
+    participant Stocker
+    
+    Note over VendingMachine: During Purchase
+    User->>VendingMachine: vendFromTrack()
+    VendingMachine->>VoteToken: mint(buyer, voteAmount)
+    VendingMachine->>TreasuryDistributor: onPurchase(buyer, token, amount, stockerShareBps)
+    alt Not in current cycle
+        TreasuryDistributor->>TreasuryDistributor: currentBuyers.push(buyer)
+        TreasuryDistributor->>TreasuryDistributor: isInCurrentCycle[buyer] = true
+    end
+    TreasuryDistributor->>VoteToken: balanceOf(buyer)
+    VoteToken-->>TreasuryDistributor: balance
+    TreasuryDistributor->>TreasuryDistributor: newEligible = balance - lastIncludedBalance[buyer]
+    TreasuryDistributor->>TreasuryDistributor: totalEligible += (newEligible - eligibleBalance[buyer])
+    TreasuryDistributor->>TreasuryDistributor: eligibleBalance[buyer] = newEligible
+    TreasuryDistributor->>TreasuryDistributor: stockerRevenue[token] += amount * stockerShareBps / 10000
+    TreasuryDistributor->>TreasuryDistributor: consumerRevenue[token] += amount * (10000 - stockerShareBps) / 10000
+    
+    Note over TreasuryDistributor: Periodic Distribution
+    TreasuryDistributor->>TreasuryDistributor: check isCycleComplete()
+    
+    Note over TreasuryDistributor: Distribute Stocker Revenue
+    loop For each token in allowedTokens
+        TreasuryDistributor->>Stocker: transfer(token, stockerRevenue[token])
+    end
+    
+    Note over TreasuryDistributor: Distribute Consumer Revenue
+    loop For each buyer in currentBuyers
+        TreasuryDistributor->>TreasuryDistributor: sharePercent = eligibleBalance[buyer] / totalEligible
+        loop For each token
+            TreasuryDistributor->>TreasuryDistributor: tokenShare = consumerRevenue[token] * sharePercent
+            TreasuryDistributor->>User: transfer(token, tokenShare)
+        end
+        TreasuryDistributor->>VoteToken: balanceOf(buyer)
+        TreasuryDistributor->>TreasuryDistributor: lastIncludedBalance[buyer] = balance
+        TreasuryDistributor->>TreasuryDistributor: delete eligibleBalance[buyer]
+        TreasuryDistributor->>TreasuryDistributor: delete isInCurrentCycle[buyer]
+    end
+    
+    TreasuryDistributor->>TreasuryDistributor: delete currentBuyers array
+    TreasuryDistributor->>TreasuryDistributor: totalEligible = 0
+```
+
+### State Diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle: Deploy Contract
+    
+    Idle --> TrackingBuyers: First Purchase
+    
+    TrackingBuyers --> TrackingBuyers: Purchase Made (Update Eligibility)
+    
+    TrackingBuyers --> ClaimingRevenue: Cycle Complete
+    
+    ClaimingRevenue --> CalculatingShares: Revenue Claimed
+    note right of ClaimingRevenue
+        Withdraw all tokens
+        from VendingMachine
+    end note
+    
+    CalculatingShares --> Distributing: Shares Calculated
+    note right of CalculatingShares
+        For each buyer:
+        share = eligible/total
+    end note
+    
+    Distributing --> Distributing: Transfer to Buyer
+    
+    Distributing --> Resetting: All Transfers Complete
+    note right of Distributing
+        Transfer each token
+        Update lastIncluded
+        Delete mappings
+    end note
+    
+    Resetting --> Idle: New Cycle Started
+    note right of Resetting
+        Clear buyers array
+        Reset totalEligible
+    end note
+```
+
+## 6. Security Considerations
+
+- **Sybil Resistance**: Vending machine's physical constraints prevent token farming
+- **Access Control**: Treasury role delegated to immutable contract
+- **Integer Overflow**: Built-in Solidity 0.8.20+ protection
+- **Failed Transfers**: Continue distribution even if individual transfers fail
+- **Hook Security**: Only authorized contracts can trigger hooks
+- **Cycle Integrity**: Time-based cycles using block.timestamp
+- **Double Distribution Prevention**: Cumulative tracking ensures fairness
+
+## 7. Gas Optimization
+
+- **Purchase-Time Tracking**: Buyers pay for their own array addition
+- **Pre-calculated Eligible Balances**: No balance lookups during distribution
+- **Efficient Iteration**: Only iterate buyers who participated in cycle
+- **Batch Processing**: Can process multiple transfers in single transaction
+- **Storage Packing**: Optimize struct layouts for minimal storage slots
+
+## 8. Testing Requirements
+
+- Unit tests for buyer array management
+- Integration tests with VendingMachine purchases
+- Cycle completion and transition tests
+- Edge cases: duplicate buyers, zero balances, transfers
+- Gas consumption benchmarks for various buyer counts
+- Multi-cycle distribution accuracy tests
+
+## 9. Open Questions
+
+- What cycle lengths should be supported? (e.g., 1 week, 2 weeks, 1 month, 3 months)
+- Default stocker share percentage per product? (Range: 10-50% depending on product margins)
+- Should there be min/max limits on stockerShareBps per product?
+- Maximum buyers array size before needing pagination?
+- Minimum distribution threshold to skip dust amounts?
+- Gas funding mechanism for autonomous operation?
+- Should DEX pools be excluded from distributions?
+- Can product stocker shares be updated after initial configuration?
+- Should cycle length be updatable after deployment or immutable?
+
+## 10. Glossary
+
+- **Cycle**: Fixed time interval between distributions (configurable at initialization)
+- **Current Buyers**: Array of addresses that participated in current cycle
+- **Eligible Balance**: Current token balance minus last included balance
+- **Last Included Balance**: Token balance that was included in the last distribution
+- **Product Stocker Share**: Per-product percentage of revenue for the stocker (stored in Product struct)
+- **Stocker Revenue**: Accumulated stocker portion from all sales in a cycle
+- **Consumer Revenue**: Accumulated consumer portion from all sales in a cycle
+- **Total Eligible**: Sum of all eligible balances in current cycle
+- **Allowed Tokens**: List of payment tokens accepted (USDC, USDT, DAI - all 1e18 decimals)
+- **Purchase Hook**: Function called on vending machine sales
+- **Push Distribution**: Automatic transfer without user action

--- a/script/DeployVendingMachine.s.sol
+++ b/script/DeployVendingMachine.s.sol
@@ -38,10 +38,7 @@ contract DeployVendingMachine is Script {
     uint256[] memory initialPrices = new uint256[](config.products.length);
 
     for (uint256 i = 0; i < config.products.length; i++) {
-      initialProducts[i] = IVendingMachine.Product(
-        config.products[i].name, 
-        config.products[i].ipfsHash
-      );
+      initialProducts[i] = IVendingMachine.Product(config.products[i].name, config.products[i].ipfsHash);
       initialStocks[i] = config.products[i].stock;
       initialPrices[i] = config.products[i].price;
     }
@@ -118,7 +115,6 @@ contract DeployVendingMachine is Script {
       config.products[i].ipfsHash = vm.parseJsonString(json, string.concat(basePath, '.ipfsHash'));
       config.products[i].stock = vm.parseJsonUint(json, string.concat(basePath, '.stock'));
       config.products[i].price = vm.parseJsonUint(json, string.concat(basePath, '.price'));
-      
     }
 
     validateConfig(config);

--- a/script/DeployVendingMachine.s.sol
+++ b/script/DeployVendingMachine.s.sol
@@ -20,8 +20,6 @@ contract DeployVendingMachine is Script {
     string ipfsHash;
     uint256 stock;
     uint256 price;
-    uint256 stockerShareBps;
-    address stockerAddress;
   }
 
   function run() external returns (VendingMachine vendingMachine, address voteToken) {
@@ -42,9 +40,7 @@ contract DeployVendingMachine is Script {
     for (uint256 i = 0; i < config.products.length; i++) {
       initialProducts[i] = IVendingMachine.Product(
         config.products[i].name, 
-        config.products[i].ipfsHash,
-        config.products[i].stockerShareBps,
-        config.products[i].stockerAddress
+        config.products[i].ipfsHash
       );
       initialStocks[i] = config.products[i].stock;
       initialPrices[i] = config.products[i].price;
@@ -123,19 +119,6 @@ contract DeployVendingMachine is Script {
       config.products[i].stock = vm.parseJsonUint(json, string.concat(basePath, '.stock'));
       config.products[i].price = vm.parseJsonUint(json, string.concat(basePath, '.price'));
       
-      // Try to parse stockerShareBps, default to 2000 (20%) if not present
-      try vm.parseJsonUint(json, string.concat(basePath, '.stockerShareBps')) returns (uint256 share) {
-        config.products[i].stockerShareBps = share;
-      } catch {
-        config.products[i].stockerShareBps = 2000; // Default 20%
-      }
-      
-      // Try to parse stockerAddress, must be provided
-      try vm.parseJsonAddress(json, string.concat(basePath, '.stockerAddress')) returns (address stocker) {
-        config.products[i].stockerAddress = stocker;
-      } catch {
-        revert('stockerAddress must be provided for each product');
-      }
     }
 
     validateConfig(config);

--- a/src/contracts/TreasuryDistributor.sol
+++ b/src/contracts/TreasuryDistributor.sol
@@ -1,0 +1,437 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ITreasuryDistributor} from '../interfaces/ITreasuryDistributor.sol';
+import {IVoteToken} from '../interfaces/IVoteToken.sol';
+import {IVendingMachine} from '../interfaces/IVendingMachine.sol';
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import {SafeERC20} from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import {ReentrancyGuard} from '@openzeppelin/contracts/utils/ReentrancyGuard.sol';
+import {Initializable} from '@openzeppelin/contracts/proxy/utils/Initializable.sol';
+
+/**
+ * @title TreasuryDistributor
+ * @notice Distributes vending machine revenue to vote token holders with per-product stocker shares
+ * @dev Uses cycle-based distribution with pre-calculated revenue splits
+ */
+contract TreasuryDistributor is ITreasuryDistributor, ReentrancyGuard, Initializable {
+  using SafeERC20 for IERC20;
+
+  // State variables
+  IVoteToken public voteToken;
+  IVendingMachine public vendingMachine;
+  uint256 public cycleLength;
+  address[] public currentBuyers;
+  address[] public stockersWithRevenue; // Track stockers that have revenue this cycle
+  
+  mapping(address => uint256) public eligibleBalance;
+  mapping(address => uint256) public lastIncludedBalance;
+  mapping(address => bool) public isInCurrentCycle;
+  mapping(address => mapping(address => uint256)) public stockerRevenue; // stocker => token => amount
+  mapping(address => uint256) public consumerRevenue;
+  mapping(address => bool) public isAllowedToken;
+  mapping(address => bool) public hasStockerRevenue; // track which stockers have revenue
+
+  uint256 public totalEligible;
+  uint256 public currentCycle;
+  uint256 public lastCycleTimestamp;
+
+  /**
+   * @notice Initializes the treasury distributor
+   * @param _voteToken The vote token used for calculating distributions
+   * @param _vendingMachine The vending machine contract
+   * @param _cycleLength The distribution cycle length in seconds
+   */
+  function initialize(
+    address _voteToken,
+    address _vendingMachine,
+    uint256 _cycleLength
+  ) external initializer {
+    if (_voteToken == address(0)) revert InvalidAddress();
+    if (_vendingMachine == address(0)) revert InvalidAddress();
+    if (_cycleLength == 0) revert InvalidCycleLength();
+
+    voteToken = IVoteToken(_voteToken);
+    vendingMachine = IVendingMachine(_vendingMachine);
+    cycleLength = _cycleLength;
+    
+    // Sync allowed tokens with vending machine
+    _syncAllowedTokens();
+    
+    lastCycleTimestamp = block.timestamp;
+    currentCycle = 1;
+  }
+
+  /**
+   * @notice Syncs allowed tokens from the vending machine
+   */
+  function _syncAllowedTokens() internal {
+    // Get accepted tokens directly from vending machine
+    // The vending machine has acceptedTokenList as a public array
+    // We need to query it to get all accepted tokens
+    uint256 i = 0;
+    while (true) {
+      try vendingMachine.acceptedTokenList(i) returns (address token) {
+        if (!isAllowedToken[token]) {
+          isAllowedToken[token] = true;
+        }
+        i++;
+      } catch {
+        break;
+      }
+    }
+  }
+
+  /**
+   * @notice Called by VendingMachine on each purchase to track revenue and buyers
+   */
+  function onPurchase(
+    address buyer,
+    address token,
+    uint256 amount,
+    uint256 stockerShareBps,
+    address stockerAddress
+  ) external override {
+    if (msg.sender != address(vendingMachine)) revert NotAuthorized();
+    if (buyer == address(0)) revert InvalidAddress();
+    if (!isAllowedToken[token]) revert InvalidAddress();
+    if (amount == 0) revert InvalidAmount();
+    if (stockerShareBps > 10000) revert InvalidAmount();
+    if (stockerAddress == address(0)) revert InvalidAddress();
+
+    // Add buyer to current cycle if not already added
+    if (!isInCurrentCycle[buyer]) {
+      currentBuyers.push(buyer);
+      isInCurrentCycle[buyer] = true;
+    }
+
+    // Update eligible balance
+    uint256 currentBalance = voteToken.balanceOf(buyer);
+    uint256 newEligible = currentBalance > lastIncludedBalance[buyer] 
+      ? currentBalance - lastIncludedBalance[buyer] 
+      : 0;
+    
+    // Update total eligible supply
+    totalEligible = totalEligible - eligibleBalance[buyer] + newEligible;
+    eligibleBalance[buyer] = newEligible;
+
+    // Split and track revenue
+    uint256 stockerAmount = (amount * stockerShareBps) / 10000;
+    uint256 consumerAmount = amount - stockerAmount;
+    
+    // Track revenue for specific stocker
+    if (stockerAmount > 0) {
+      // Add to stockersWithRevenue array if not already added
+      if (!hasStockerRevenue[stockerAddress]) {
+        stockersWithRevenue.push(stockerAddress);
+        hasStockerRevenue[stockerAddress] = true;
+      }
+      stockerRevenue[stockerAddress][token] += stockerAmount;
+    }
+    consumerRevenue[token] += consumerAmount;
+
+    emit PurchaseTracked(buyer, token, amount, stockerAmount, consumerAmount);
+  }
+
+  /**
+   * @notice Executes distribution to stocker and consumers
+   */
+  function distribute() external override nonReentrant {
+    if (!isCycleComplete()) revert CycleNotComplete();
+
+    uint256 buyerCount = currentBuyers.length;
+    
+    // Distribute revenue to stockers
+    _distributeStockerRevenue();
+    
+    // Distribute revenue to consumers
+    _distributeConsumerRevenue();
+    
+    // Reset state for new cycle
+    _resetCycleState();
+    
+    // Start new cycle
+    _startNewCycle(buyerCount);
+  }
+
+  /**
+   * @notice Internal function to distribute revenue to all stockers
+   */
+  function _distributeStockerRevenue() internal {
+    for (uint256 i = 0; i < stockersWithRevenue.length; i++) {
+      address stocker = stockersWithRevenue[i];
+      _distributeToStocker(stocker);
+    }
+  }
+
+  /**
+   * @notice Internal function to distribute revenue to a specific stocker
+   * @param stocker The stocker address to pay
+   */
+  function _distributeToStocker(address stocker) internal {
+    for (uint256 j = 0; j < _getAcceptedTokenCount(); j++) {
+      address token = vendingMachine.acceptedTokenList(j);
+      uint256 stockerAmount = stockerRevenue[stocker][token];
+      
+      if (stockerAmount > 0) {
+        _transferRevenue(token, stocker, stockerAmount);
+        emit StockerPaid(stocker, token, stockerAmount);
+      }
+    }
+  }
+
+  /**
+   * @notice Internal function to distribute consumer revenue
+   */
+  function _distributeConsumerRevenue() internal {
+    if (totalEligible == 0) return;
+    
+    // First, collect all consumer revenue from vending machine
+    _collectConsumerRevenue();
+    
+    // Then distribute to each buyer
+    _distributeToBuyers();
+  }
+
+  /**
+   * @notice Internal function to collect consumer revenue from vending machine
+   */
+  function _collectConsumerRevenue() internal {
+    // Iterate through all tokens that have consumer revenue
+    // We don't need to maintain allowedTokens array since we track via consumerRevenue mapping
+    for (uint256 i = 0; i < _getAcceptedTokenCount(); i++) {
+      address token = vendingMachine.acceptedTokenList(i);
+      uint256 consumerAmount = consumerRevenue[token];
+      
+      if (consumerAmount > 0) {
+        IERC20(token).safeTransferFrom(address(vendingMachine), address(this), consumerAmount);
+      }
+    }
+  }
+
+  /**
+   * @notice Internal function to distribute revenue to all buyers
+   */
+  function _distributeToBuyers() internal {
+    uint256 buyerCount = currentBuyers.length;
+    
+    for (uint256 i = 0; i < buyerCount; i++) {
+      address buyer = currentBuyers[i];
+      _distributeToBuyer(buyer);
+    }
+  }
+
+  /**
+   * @notice Internal function to distribute revenue to a specific buyer
+   * @param buyer The buyer address to pay
+   */
+  function _distributeToBuyer(address buyer) internal {
+    uint256 buyerEligible = eligibleBalance[buyer];
+    
+    if (buyerEligible > 0) {
+      uint256 sharePercent = (buyerEligible * 1e18) / totalEligible;
+      
+      _distributeTokenShareToBuyer(buyer, sharePercent);
+      
+      // Update last included balance
+      lastIncludedBalance[buyer] = voteToken.balanceOf(buyer);
+    }
+    
+    // Clean up buyer data
+    delete eligibleBalance[buyer];
+    delete isInCurrentCycle[buyer];
+  }
+
+  /**
+   * @notice Internal function to distribute token shares to a buyer
+   * @param buyer The buyer address
+   * @param sharePercent The buyer's share percentage (scaled by 1e18)
+   */
+  function _distributeTokenShareToBuyer(address buyer, uint256 sharePercent) internal {
+    for (uint256 j = 0; j < _getAcceptedTokenCount(); j++) {
+      address token = vendingMachine.acceptedTokenList(j);
+      uint256 tokenConsumerRevenue = consumerRevenue[token];
+      
+      if (tokenConsumerRevenue > 0) {
+        uint256 tokenShare = (tokenConsumerRevenue * sharePercent) / 1e18;
+        
+        if (tokenShare > 0) {
+          IERC20(token).safeTransfer(buyer, tokenShare);
+          emit ConsumerPaid(buyer, token, tokenShare);
+        }
+      }
+    }
+  }
+
+  /**
+   * @notice Internal function to transfer revenue from vending machine
+   * @param token The token to transfer
+   * @param to The recipient address
+   * @param amount The amount to transfer
+   */
+  function _transferRevenue(address token, address to, uint256 amount) internal {
+    // Transfer from vending machine to this contract
+    IERC20(token).safeTransferFrom(address(vendingMachine), address(this), amount);
+    // Transfer to recipient
+    IERC20(token).safeTransfer(to, amount);
+  }
+
+  /**
+   * @notice Internal function to reset all cycle state
+   */
+  function _resetCycleState() internal {
+    // Reset buyer tracking
+    delete currentBuyers;
+    totalEligible = 0;
+    
+    // Reset stocker revenue tracking
+    _resetStockerRevenue();
+    
+    // Reset consumer revenue tracking
+    _resetConsumerRevenue();
+  }
+
+  /**
+   * @notice Internal function to reset stocker revenue tracking
+   */
+  function _resetStockerRevenue() internal {
+    for (uint256 i = 0; i < stockersWithRevenue.length; i++) {
+      address stocker = stockersWithRevenue[i];
+      for (uint256 j = 0; j < _getAcceptedTokenCount(); j++) {
+        address token = vendingMachine.acceptedTokenList(j);
+        delete stockerRevenue[stocker][token];
+      }
+      delete hasStockerRevenue[stocker];
+    }
+    delete stockersWithRevenue;
+  }
+
+  /**
+   * @notice Internal function to reset consumer revenue tracking
+   */
+  function _resetConsumerRevenue() internal {
+    for (uint256 i = 0; i < _getAcceptedTokenCount(); i++) {
+      address token = vendingMachine.acceptedTokenList(i);
+      delete consumerRevenue[token];
+    }
+  }
+
+  /**
+   * @notice Internal function to get the count of accepted tokens from vending machine
+   */
+  function _getAcceptedTokenCount() internal view returns (uint256 count) {
+    // Count tokens by trying to access the array until it reverts
+    while (true) {
+      try vendingMachine.acceptedTokenList(count) returns (address) {
+        count++;
+      } catch {
+        break;
+      }
+    }
+  }
+
+  /**
+   * @notice Internal function to start a new cycle
+   * @param previousBuyerCount The number of buyers in the previous cycle
+   */
+  function _startNewCycle(uint256 previousBuyerCount) internal {
+    currentCycle++;
+    lastCycleTimestamp = block.timestamp;
+    
+    emit DistributionExecuted(currentCycle - 1, previousBuyerCount, block.timestamp);
+    emit NewCycleStarted(currentCycle, block.timestamp);
+  }
+
+  /**
+   * @notice Checks if current cycle is complete
+   */
+  function isCycleComplete() public view override returns (bool) {
+    return block.timestamp >= lastCycleTimestamp + cycleLength;
+  }
+
+  /**
+   * @notice Gets the current cycle number
+   */
+  function getCurrentCycle() external view override returns (uint256) {
+    return currentCycle;
+  }
+
+  /**
+   * @notice Gets the number of buyers in current cycle
+   */
+  function getCurrentBuyerCount() external view override returns (uint256) {
+    return currentBuyers.length;
+  }
+
+  /**
+   * @notice Gets accumulated stocker revenue for a specific stocker and token
+   * @param stocker The stocker address
+   * @param token The token address
+   */
+  function getStockerRevenue(address stocker, address token) external view returns (uint256) {
+    return stockerRevenue[stocker][token];
+  }
+  
+  /**
+   * @notice Gets total stocker revenue for a token across all stockers
+   * @param token The token address
+   */
+  function getTotalStockerRevenue(address token) external view returns (uint256) {
+    uint256 total = 0;
+    for (uint256 i = 0; i < stockersWithRevenue.length; i++) {
+      total += stockerRevenue[stockersWithRevenue[i]][token];
+    }
+    return total;
+  }
+
+  /**
+   * @notice Gets accumulated consumer revenue for a token
+   */
+  function getConsumerRevenue(address token) external view override returns (uint256) {
+    return consumerRevenue[token];
+  }
+
+  /**
+   * @notice Gets the eligible balance for a buyer
+   */
+  function getEligibleBalance(address buyer) external view override returns (uint256) {
+    return eligibleBalance[buyer];
+  }
+
+  /**
+   * @notice Gets time until next distribution
+   */
+  function getTimeUntilNextDistribution() external view override returns (uint256) {
+    uint256 nextDistribution = lastCycleTimestamp + cycleLength;
+    if (block.timestamp >= nextDistribution) {
+      return 0;
+    }
+    return nextDistribution - block.timestamp;
+  }
+
+  /**
+   * @notice Gets the list of current buyers
+   */
+  function getCurrentBuyers() external view returns (address[] memory) {
+    return currentBuyers;
+  }
+
+  /**
+   * @notice Gets the list of allowed tokens from the vending machine
+   */
+  function getAllowedTokens() external view returns (address[] memory) {
+    uint256 count = _getAcceptedTokenCount();
+    address[] memory tokens = new address[](count);
+    for (uint256 i = 0; i < count; i++) {
+      tokens[i] = vendingMachine.acceptedTokenList(i);
+    }
+    return tokens;
+  }
+  
+  /**
+   * @notice Gets the list of stockers with revenue in current cycle
+   */
+  function getStockersWithRevenue() external view returns (address[] memory) {
+    return stockersWithRevenue;
+  }
+}

--- a/src/contracts/TreasuryDistributor.sol
+++ b/src/contracts/TreasuryDistributor.sol
@@ -98,23 +98,9 @@ contract TreasuryDistributor is ITreasuryDistributor, ReentrancyGuard, Initializ
     uint256 amount
   ) external override {
     if (msg.sender != address(vendingMachine)) revert NotAuthorized();
+    if (buyer == address(0)) revert InvalidAddress();
     if (!isAllowedToken[token]) revert InvalidAddress();
     if (amount == 0) revert InvalidAmount();
-
-    // Split revenue
-    uint256 stockerAmount = (amount * stockerShareBps) / 10000;
-    uint256 consumerAmount = amount - stockerAmount;
-    
-    // Always track stocker revenue
-    stockerRevenue[token] += stockerAmount;
-    
-    // If buyer is address(0), stocker still gets their share
-    // but the consumer portion is not distributed (effectively burned/kept by treasury)
-    if (buyer == address(0)) {
-      // No buyer to track, consumer portion stays in vending machine
-      emit PurchaseTracked(buyer, token, amount, stockerAmount, consumerAmount);
-      return;
-    }
 
     // Add buyer to current cycle if not already added
     if (!isInCurrentCycle[buyer]) {
@@ -132,7 +118,11 @@ contract TreasuryDistributor is ITreasuryDistributor, ReentrancyGuard, Initializ
     totalEligible = totalEligible - eligibleBalance[buyer] + newEligible;
     eligibleBalance[buyer] = newEligible;
 
-    // Track consumer revenue for distribution
+    // Split and track revenue
+    uint256 stockerAmount = (amount * stockerShareBps) / 10000;
+    uint256 consumerAmount = amount - stockerAmount;
+    
+    stockerRevenue[token] += stockerAmount;
     consumerRevenue[token] += consumerAmount;
 
     emit PurchaseTracked(buyer, token, amount, stockerAmount, consumerAmount);

--- a/src/contracts/VendingMachine.sol
+++ b/src/contracts/VendingMachine.sol
@@ -161,9 +161,9 @@ contract VendingMachine is IVendingMachine, ReentrancyGuard, AccessControl {
       voteToken.mint(recipient, price);
     }
 
-    // Notify treasury distributor if configured
-    // Pass recipient as-is (can be address(0) if no vote tokens were minted)
-    if (address(treasuryDistributor) != address(0)) {
+    // Notify treasury distributor if configured and there's a recipient
+    // Skip revenue sharing if no vote tokens were minted (recipient is address(0))
+    if (address(treasuryDistributor) != address(0) && recipient != address(0)) {
       treasuryDistributor.onPurchase(
         recipient,
         token,

--- a/src/contracts/VendingMachine.sol
+++ b/src/contracts/VendingMachine.sol
@@ -18,7 +18,7 @@ contract VendingMachine is IVendingMachine, ReentrancyGuard, AccessControl {
   uint8 public immutable NUM_TRACKS;
   uint256 public immutable MAX_STOCK_PER_TRACK;
   VoteToken public immutable voteToken;
-  address[] public acceptedTokenList;
+  address[] private acceptedTokenList;
   
   ITreasuryDistributor public treasuryDistributor;
 
@@ -161,9 +161,9 @@ contract VendingMachine is IVendingMachine, ReentrancyGuard, AccessControl {
       voteToken.mint(recipient, price);
     }
 
-    // Notify treasury distributor if configured and there's a recipient
+    // Notify treasury distributor if there's a recipient
     // Skip revenue sharing if no vote tokens were minted (recipient is address(0))
-    if (address(treasuryDistributor) != address(0) && recipient != address(0)) {
+    if (recipient != address(0)) {
       treasuryDistributor.onPurchase(
         recipient,
         token,

--- a/src/contracts/VendingMachine.sol
+++ b/src/contracts/VendingMachine.sol
@@ -162,9 +162,10 @@ contract VendingMachine is IVendingMachine, ReentrancyGuard, AccessControl {
     }
 
     // Notify treasury distributor if configured
+    // Pass recipient as-is (can be address(0) if no vote tokens were minted)
     if (address(treasuryDistributor) != address(0)) {
       treasuryDistributor.onPurchase(
-        recipient != address(0) ? recipient : msg.sender,
+        recipient,
         token,
         price
       );

--- a/src/interfaces/ITreasuryDistributor.sol
+++ b/src/interfaces/ITreasuryDistributor.sol
@@ -4,55 +4,154 @@ pragma solidity ^0.8.20;
 /**
  * @title ITreasuryDistributor
  * @notice Interface for distributing vending machine revenue to vote token holders
- * @dev Implements cycle-based proportional distribution with per-product stocker shares
+ * @dev Implements cycle-based proportional distribution with configurable distribution percentage
+ * @dev Revenue not distributed is retained for owner withdrawal
  */
 interface ITreasuryDistributor {
   // Events
+  /**
+   * @notice Emitted when a purchase is tracked for revenue distribution
+   * @param buyer Address of the purchaser who will receive distributions
+   * @param token Payment token used for the purchase
+   * @param amount Total payment amount
+   * @param distributedAmount Amount added to distribution pool
+   * @param retainedAmount Amount retained for owner withdrawal
+   */
   event PurchaseTracked(
     address indexed buyer,
     address indexed token,
     uint256 amount,
-    uint256 stockerAmount,
-    uint256 consumerAmount
+    uint256 distributedAmount,
+    uint256 retainedAmount
   );
 
+  /**
+   * @notice Emitted when a distribution cycle is completed
+   * @param cycle The cycle number that was completed
+   * @param buyerCount Number of unique buyers in the cycle
+   * @param timestamp When the distribution occurred
+   */
   event DistributionExecuted(
     uint256 indexed cycle,
     uint256 buyerCount,
     uint256 timestamp
   );
 
-  event StockerPaid(
-    address indexed stocker,
-    address indexed token,
-    uint256 amount
-  );
-
+  /**
+   * @notice Emitted when a consumer receives their distribution
+   * @param consumer Address receiving the distribution
+   * @param token Token being distributed
+   * @param amount Amount distributed to the consumer
+   */
   event ConsumerPaid(
     address indexed consumer,
     address indexed token,
     uint256 amount
   );
 
+  /**
+   * @notice Emitted when a new distribution cycle begins
+   * @param cycle The new cycle number
+   * @param timestamp When the cycle started
+   */
   event NewCycleStarted(
     uint256 indexed cycle,
     uint256 timestamp
   );
 
+  /**
+   * @notice Emitted when the distribution percentage is updated
+   * @param oldPercentage Previous percentage (in basis points)
+   * @param newPercentage New percentage (in basis points)
+   */
+  event DistributionPercentageUpdated(
+    uint256 oldPercentage,
+    uint256 newPercentage
+  );
+
+  /**
+   * @notice Emitted when the owner withdraws retained revenue
+   * @param token Token withdrawn
+   * @param amount Amount withdrawn
+   * @param recipient Address receiving the funds
+   */
+  event RetainedRevenueWithdrawn(
+    address indexed token,
+    uint256 amount,
+    address indexed recipient
+  );
+
   // Errors
+  /**
+   * @notice Thrown when the caller is not authorized to perform the action
+   */
   error NotAuthorized();
+  
+  /**
+   * @notice Thrown when trying to distribute before the cycle is complete
+   */
   error CycleNotComplete();
+  
+  /**
+   * @notice Thrown when an invalid address (e.g., zero address) is provided
+   */
   error InvalidAddress();
+  
+  /**
+   * @notice Thrown when an invalid amount is provided
+   */
   error InvalidAmount();
+  
+  /**
+   * @notice Thrown when an invalid cycle length is provided
+   */
   error InvalidCycleLength();
+  
+  /**
+   * @notice Thrown when an invalid percentage (> 100%) is provided
+   */
+  error InvalidPercentage();
+  
+  /**
+   * @notice Thrown when a token transfer fails
+   */
   error TransferFailed();
+  
+  /**
+   * @notice Thrown when trying to initialize an already initialized contract
+   */
   error AlreadyInitialized();
+  
+  /**
+   * @notice Thrown when trying to withdraw with no revenue available
+   */
+  error NoRevenueToWithdraw();
+  
+  /**
+   * @notice Thrown when the contract has insufficient balance for a withdrawal
+   */
+  error InsufficientBalance();
+
+  /**
+   * @notice Initializes the treasury distributor contract
+   * @param _voteToken Address of the vote token used for calculating distributions
+   * @param _vendingMachine Address of the vending machine contract
+   * @param _cycleLength Duration of each distribution cycle in seconds
+   * @param _distributionPercentageBps Percentage of revenue to distribute (in basis points, e.g., 8000 = 80%)
+   */
+  function initialize(
+    address _voteToken,
+    address _vendingMachine,
+    uint256 _cycleLength,
+    uint256 _distributionPercentageBps
+  ) external;
 
   /**
    * @notice Called by VendingMachine on each purchase to track revenue and buyers
-   * @param buyer Address of the purchaser
-   * @param token Payment token used
-   * @param amount Payment amount
+   * @dev Only the vending machine can call this function
+   * @param buyer Address of the purchaser who will receive vote tokens
+   * @param token Payment token used for the purchase
+   * @param amount Total payment amount before distribution split
    */
   function onPurchase(
     address buyer,
@@ -61,53 +160,81 @@ interface ITreasuryDistributor {
   ) external;
 
   /**
-   * @notice Executes distribution to stocker and consumers
-   * @dev Can only be called when cycle is complete
+   * @notice Executes distribution to vote token holders for the completed cycle
+   * @dev Can only be called after the current cycle is complete
+   * @dev Distributes accumulated revenue proportionally based on vote token holdings
    */
   function distribute() external;
 
   /**
-   * @notice Checks if current cycle is complete
-   * @return bool True if distribution can occur
+   * @notice Updates the percentage of revenue that gets distributed vs retained
+   * @dev Only callable by contract owner
+   * @param newPercentageBps New distribution percentage in basis points (0-10000)
+   */
+  function setDistributionPercentage(uint256 newPercentageBps) external;
+
+  /**
+   * @notice Withdraws retained (non-distributed) revenue
+   * @dev Only callable by contract owner
+   * @param token Address of the token to withdraw
+   * @param recipient Address to receive the withdrawn funds
+   */
+  function withdrawRetainedRevenue(address token, address recipient) external;
+
+  /**
+   * @notice Checks if the current distribution cycle is complete
+   * @return bool True if enough time has passed and distribution can occur
    */
   function isCycleComplete() external view returns (bool);
 
   /**
    * @notice Gets the current cycle number
-   * @return uint256 Current cycle
+   * @return uint256 Current cycle number (starts at 1)
    */
   function getCurrentCycle() external view returns (uint256);
 
   /**
-   * @notice Gets the number of buyers in current cycle
-   * @return uint256 Number of unique buyers
+   * @notice Gets the number of unique buyers in the current cycle
+   * @return uint256 Number of unique buyers who have made purchases
    */
   function getCurrentBuyerCount() external view returns (uint256);
 
   /**
-   * @notice Gets accumulated stocker revenue for a token
-   * @param token Token address
-   * @return uint256 Stocker revenue amount
+   * @notice Gets the current distribution percentage
+   * @return uint256 Distribution percentage in basis points
    */
-  function getStockerRevenue(address token) external view returns (uint256);
+  function getDistributionPercentage() external view returns (uint256);
 
   /**
-   * @notice Gets accumulated consumer revenue for a token
-   * @param token Token address
-   * @return uint256 Consumer revenue amount
+   * @notice Gets accumulated revenue for distribution for a specific token
+   * @param token Token address to query
+   * @return uint256 Amount of revenue accumulated for distribution
    */
-  function getConsumerRevenue(address token) external view returns (uint256);
+  function getDistributableRevenue(address token) external view returns (uint256);
 
   /**
-   * @notice Gets the eligible balance for a buyer
-   * @param buyer Buyer address
-   * @return uint256 Eligible balance
+   * @notice Gets retained revenue available for withdrawal for a specific token
+   * @param token Token address to query
+   * @return uint256 Amount of retained revenue available for withdrawal
+   */
+  function getRetainedRevenue(address token) external view returns (uint256);
+
+  /**
+   * @notice Gets the eligible vote token balance for a buyer in the current cycle
+   * @param buyer Buyer address to query
+   * @return uint256 Eligible balance that will be used for distribution calculations
    */
   function getEligibleBalance(address buyer) external view returns (uint256);
 
   /**
-   * @notice Gets time until next distribution
-   * @return uint256 Seconds until cycle complete
+   * @notice Gets time remaining until the next distribution can occur
+   * @return uint256 Seconds until cycle completes (0 if already complete)
    */
   function getTimeUntilNextDistribution() external view returns (uint256);
+
+  /**
+   * @notice Gets the contract owner address
+   * @return address Owner address who can withdraw retained revenue
+   */
+  function owner() external view returns (address);
 }

--- a/src/interfaces/ITreasuryDistributor.sol
+++ b/src/interfaces/ITreasuryDistributor.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title ITreasuryDistributor
+ * @notice Interface for distributing vending machine revenue to vote token holders
+ * @dev Implements cycle-based proportional distribution with per-product stocker shares
+ */
+interface ITreasuryDistributor {
+  // Events
+  event PurchaseTracked(
+    address indexed buyer,
+    address indexed token,
+    uint256 amount,
+    uint256 stockerAmount,
+    uint256 consumerAmount
+  );
+
+  event DistributionExecuted(
+    uint256 indexed cycle,
+    uint256 buyerCount,
+    uint256 timestamp
+  );
+
+  event StockerPaid(
+    address indexed stocker,
+    address indexed token,
+    uint256 amount
+  );
+
+  event ConsumerPaid(
+    address indexed consumer,
+    address indexed token,
+    uint256 amount
+  );
+
+  event NewCycleStarted(
+    uint256 indexed cycle,
+    uint256 timestamp
+  );
+
+  // Errors
+  error NotAuthorized();
+  error CycleNotComplete();
+  error InvalidAddress();
+  error InvalidAmount();
+  error InvalidCycleLength();
+  error TransferFailed();
+  error AlreadyInitialized();
+
+  /**
+   * @notice Called by VendingMachine on each purchase to track revenue and buyers
+   * @param buyer Address of the purchaser
+   * @param token Payment token used
+   * @param amount Payment amount
+   * @param stockerShareBps Product's stocker share in basis points
+   * @param stockerAddress Address that receives stocker share for this product
+   */
+  function onPurchase(
+    address buyer,
+    address token,
+    uint256 amount,
+    uint256 stockerShareBps,
+    address stockerAddress
+  ) external;
+
+  /**
+   * @notice Executes distribution to stocker and consumers
+   * @dev Can only be called when cycle is complete
+   */
+  function distribute() external;
+
+  /**
+   * @notice Checks if current cycle is complete
+   * @return bool True if distribution can occur
+   */
+  function isCycleComplete() external view returns (bool);
+
+  /**
+   * @notice Gets the current cycle number
+   * @return uint256 Current cycle
+   */
+  function getCurrentCycle() external view returns (uint256);
+
+  /**
+   * @notice Gets the number of buyers in current cycle
+   * @return uint256 Number of unique buyers
+   */
+  function getCurrentBuyerCount() external view returns (uint256);
+
+  /**
+   * @notice Gets accumulated stocker revenue for a specific stocker and token
+   * @param stocker Stocker address
+   * @param token Token address
+   * @return uint256 Stocker revenue amount
+   */
+  function getStockerRevenue(address stocker, address token) external view returns (uint256);
+
+  /**
+   * @notice Gets accumulated consumer revenue for a token
+   * @param token Token address
+   * @return uint256 Consumer revenue amount
+   */
+  function getConsumerRevenue(address token) external view returns (uint256);
+
+  /**
+   * @notice Gets the eligible balance for a buyer
+   * @param buyer Buyer address
+   * @return uint256 Eligible balance
+   */
+  function getEligibleBalance(address buyer) external view returns (uint256);
+
+  /**
+   * @notice Gets time until next distribution
+   * @return uint256 Seconds until cycle complete
+   */
+  function getTimeUntilNextDistribution() external view returns (uint256);
+}

--- a/src/interfaces/ITreasuryDistributor.sol
+++ b/src/interfaces/ITreasuryDistributor.sol
@@ -53,15 +53,11 @@ interface ITreasuryDistributor {
    * @param buyer Address of the purchaser
    * @param token Payment token used
    * @param amount Payment amount
-   * @param stockerShareBps Product's stocker share in basis points
-   * @param stockerAddress Address that receives stocker share for this product
    */
   function onPurchase(
     address buyer,
     address token,
-    uint256 amount,
-    uint256 stockerShareBps,
-    address stockerAddress
+    uint256 amount
   ) external;
 
   /**
@@ -89,12 +85,11 @@ interface ITreasuryDistributor {
   function getCurrentBuyerCount() external view returns (uint256);
 
   /**
-   * @notice Gets accumulated stocker revenue for a specific stocker and token
-   * @param stocker Stocker address
+   * @notice Gets accumulated stocker revenue for a token
    * @param token Token address
    * @return uint256 Stocker revenue amount
    */
-  function getStockerRevenue(address stocker, address token) external view returns (uint256);
+  function getStockerRevenue(address token) external view returns (uint256);
 
   /**
    * @notice Gets accumulated consumer revenue for a token

--- a/src/interfaces/IVendingMachine.sol
+++ b/src/interfaces/IVendingMachine.sol
@@ -11,14 +11,10 @@ interface IVendingMachine {
    * @notice Product information structure
    * @param name Product name
    * @param imageURI IPFS or HTTP URI for product image
-   * @param stockerShareBps Stocker's revenue share in basis points (e.g., 2000 = 20%)
-   * @param stockerAddress Address that receives stocker share for this product
    */
   struct Product {
     string name;
     string imageURI;
-    uint256 stockerShareBps;
-    address stockerAddress;
   }
 
   /**
@@ -79,17 +75,8 @@ interface IVendingMachine {
    * @notice Emitted when a track is restocked
    * @param trackId The track that was restocked
    * @param additionalStock Amount of stock added
-   * @param newStocker The address that restocked and becomes the new stocker
    */
-  event TrackRestocked(uint8 indexed trackId, uint256 additionalStock, address indexed newStocker);
-
-  /**
-   * @notice Emitted when a track's stocker changes
-   * @param trackId The track whose stocker changed
-   * @param previousStocker The previous stocker address
-   * @param newStocker The new stocker address
-   */
-  event StockerChanged(uint8 indexed trackId, address indexed previousStocker, address indexed newStocker);
+  event TrackRestocked(uint8 indexed trackId, uint256 additionalStock);
 
   /**
    * @notice Emitted when a track's price is set
@@ -147,13 +134,12 @@ interface IVendingMachine {
   ) external;
 
   /**
-   * @notice Add stock to an existing track and become the stocker
-   * @dev Only callable by OPERATOR_ROLE. The caller becomes the new stocker for this track.
+   * @notice Add stock to an existing track
+   * @dev Only callable by OPERATOR_ROLE
    * @param trackId Track to restock
    * @param additionalStock Amount to add (new total must not exceed MAX_STOCK_PER_TRACK)
-   * @param stockerShareBps Revenue share for the stocker in basis points (e.g., 2000 = 20%)
    */
-  function restockTrack(uint8 trackId, uint256 additionalStock, uint256 stockerShareBps) external;
+  function restockTrack(uint8 trackId, uint256 additionalStock) external;
 
   /**
    * @notice Set the price for a track
@@ -222,4 +208,10 @@ interface IVendingMachine {
    * @return The token address at the given index
    */
   function acceptedTokenList(uint256 index) external view returns (address);
+  
+  /**
+   * @notice Get all accepted tokens
+   * @return Array of accepted token addresses
+   */
+  function getAcceptedTokens() external view returns (address[] memory);
 }

--- a/src/interfaces/IVendingMachine.sol
+++ b/src/interfaces/IVendingMachine.sol
@@ -201,13 +201,6 @@ interface IVendingMachine {
    * @return Array of all tracks
    */
   function getAllTracks() external view returns (Track[] memory);
-
-  /**
-   * @notice Get accepted token at specific index
-   * @param index The index in the accepted token list
-   * @return The token address at the given index
-   */
-  function acceptedTokenList(uint256 index) external view returns (address);
   
   /**
    * @notice Get all accepted tokens

--- a/src/interfaces/IVendingMachine.sol
+++ b/src/interfaces/IVendingMachine.sol
@@ -11,10 +11,14 @@ interface IVendingMachine {
    * @notice Product information structure
    * @param name Product name
    * @param imageURI IPFS or HTTP URI for product image
+   * @param stockerShareBps Stocker's revenue share in basis points (e.g., 2000 = 20%)
+   * @param stockerAddress Address that receives stocker share for this product
    */
   struct Product {
     string name;
     string imageURI;
+    uint256 stockerShareBps;
+    address stockerAddress;
   }
 
   /**
@@ -75,8 +79,17 @@ interface IVendingMachine {
    * @notice Emitted when a track is restocked
    * @param trackId The track that was restocked
    * @param additionalStock Amount of stock added
+   * @param newStocker The address that restocked and becomes the new stocker
    */
-  event TrackRestocked(uint8 indexed trackId, uint256 additionalStock);
+  event TrackRestocked(uint8 indexed trackId, uint256 additionalStock, address indexed newStocker);
+
+  /**
+   * @notice Emitted when a track's stocker changes
+   * @param trackId The track whose stocker changed
+   * @param previousStocker The previous stocker address
+   * @param newStocker The new stocker address
+   */
+  event StockerChanged(uint8 indexed trackId, address indexed previousStocker, address indexed newStocker);
 
   /**
    * @notice Emitted when a track's price is set
@@ -134,12 +147,13 @@ interface IVendingMachine {
   ) external;
 
   /**
-   * @notice Add stock to an existing track
-   * @dev Only callable by OPERATOR_ROLE
+   * @notice Add stock to an existing track and become the stocker
+   * @dev Only callable by OPERATOR_ROLE. The caller becomes the new stocker for this track.
    * @param trackId Track to restock
    * @param additionalStock Amount to add (new total must not exceed MAX_STOCK_PER_TRACK)
+   * @param stockerShareBps Revenue share for the stocker in basis points (e.g., 2000 = 20%)
    */
-  function restockTrack(uint8 trackId, uint256 additionalStock) external;
+  function restockTrack(uint8 trackId, uint256 additionalStock, uint256 stockerShareBps) external;
 
   /**
    * @notice Set the price for a track
@@ -201,4 +215,11 @@ interface IVendingMachine {
    * @return Array of all tracks
    */
   function getAllTracks() external view returns (Track[] memory);
+
+  /**
+   * @notice Get accepted token at specific index
+   * @param index The index in the accepted token list
+   * @return The token address at the given index
+   */
+  function acceptedTokenList(uint256 index) external view returns (address);
 }

--- a/test/unit/TreasuryDistributor.t.sol
+++ b/test/unit/TreasuryDistributor.t.sol
@@ -1,0 +1,365 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import 'forge-std/Test.sol';
+import {TreasuryDistributor} from '../../src/contracts/TreasuryDistributor.sol';
+import {VendingMachine} from '../../src/contracts/VendingMachine.sol';
+import {VoteToken} from '../../src/contracts/VoteToken.sol';
+import {ITreasuryDistributor} from '../../src/interfaces/ITreasuryDistributor.sol';
+import {IVendingMachine} from '../../src/interfaces/IVendingMachine.sol';
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import {ERC20} from '@openzeppelin/contracts/token/ERC20/ERC20.sol';
+
+contract MockUSDC is ERC20 {
+  constructor() ERC20('Mock USDC', 'USDC') {
+    _mint(msg.sender, 1000000 * 10 ** 18);
+  }
+
+  function mint(address to, uint256 amount) external {
+    _mint(to, amount);
+  }
+}
+
+contract TreasuryDistributorTest is Test {
+  TreasuryDistributor public distributor;
+  VendingMachine public vendingMachine;
+  VoteToken public voteToken;
+  MockUSDC public usdc;
+
+  address public admin = address(0x1);
+  address public operator = address(0x2);
+  address public stocker1 = address(0x31);
+  address public stocker2 = address(0x32);
+  address public stocker3 = address(0x33);
+  address public alice = address(0x4);
+  address public bob = address(0x5);
+  address public charlie = address(0x6);
+
+  uint256 constant CYCLE_LENGTH = 7 days;
+  uint256 constant PRODUCT_PRICE = 10 * 10 ** 18; // $10
+  uint256 constant STOCKER_SHARE_BPS = 2000; // 20%
+
+  event PurchaseTracked(
+    address indexed buyer,
+    address indexed token,
+    uint256 amount,
+    uint256 stockerAmount,
+    uint256 consumerAmount
+  );
+
+  event DistributionExecuted(
+    uint256 indexed cycle,
+    uint256 buyerCount,
+    uint256 timestamp
+  );
+
+  function setUp() public {
+    vm.startPrank(admin);
+
+    // Deploy mock USDC
+    usdc = new MockUSDC();
+
+    // Deploy VendingMachine
+    address[] memory acceptedTokens = new address[](1);
+    acceptedTokens[0] = address(usdc);
+
+    IVendingMachine.Product[] memory products = new IVendingMachine.Product[](3);
+    products[0] = IVendingMachine.Product('Coca Cola', 'ipfs://coca-cola', STOCKER_SHARE_BPS, stocker1);
+    products[1] = IVendingMachine.Product('Pepsi', 'ipfs://pepsi', 1500, stocker2); // 15% stocker share
+    products[2] = IVendingMachine.Product('Sprite', 'ipfs://sprite', 2500, stocker3); // 25% stocker share
+
+    uint256[] memory stocks = new uint256[](3);
+    stocks[0] = 100;
+    stocks[1] = 100;
+    stocks[2] = 100;
+
+    uint256[] memory prices = new uint256[](3);
+    prices[0] = PRODUCT_PRICE;
+    prices[1] = PRODUCT_PRICE;
+    prices[2] = PRODUCT_PRICE;
+
+    vendingMachine = new VendingMachine(
+      3, // num tracks
+      100, // max stock per track
+      'Vote Token',
+      'VOTE',
+      acceptedTokens,
+      products,
+      stocks,
+      prices
+    );
+
+    voteToken = vendingMachine.voteToken();
+
+    // Deploy and initialize TreasuryDistributor
+    distributor = new TreasuryDistributor();
+    distributor.initialize(
+      address(voteToken),
+      address(vendingMachine),
+      CYCLE_LENGTH
+    );
+
+    // Configure VendingMachine
+    vendingMachine.setTreasuryDistributor(address(distributor));
+    vendingMachine.grantRole(vendingMachine.TREASURY_ROLE(), address(distributor));
+
+    // Distribute USDC to buyers
+    usdc.transfer(alice, 1000 * 10 ** 18);
+    usdc.transfer(bob, 1000 * 10 ** 18);
+    usdc.transfer(charlie, 1000 * 10 ** 18);
+
+    vm.stopPrank();
+  }
+
+  function testPurchaseTracking() public {
+    vm.startPrank(alice);
+    usdc.approve(address(vendingMachine), PRODUCT_PRICE);
+    
+    vm.expectEmit(true, true, false, true);
+    emit PurchaseTracked(
+      alice,
+      address(usdc),
+      PRODUCT_PRICE,
+      (PRODUCT_PRICE * STOCKER_SHARE_BPS) / 10000,
+      PRODUCT_PRICE - (PRODUCT_PRICE * STOCKER_SHARE_BPS) / 10000
+    );
+    
+    vendingMachine.vendFromTrack(0, address(usdc), alice);
+    vm.stopPrank();
+
+    assertEq(distributor.getCurrentBuyerCount(), 1);
+    assertEq(distributor.getStockerRevenue(stocker1, address(usdc)), 2 * 10 ** 18); // 20% of $10
+    assertEq(distributor.getConsumerRevenue(address(usdc)), 8 * 10 ** 18); // 80% of $10
+    assertEq(distributor.getEligibleBalance(alice), PRODUCT_PRICE);
+  }
+
+  function testMultiplePurchasesSameBuyer() public {
+    vm.startPrank(alice);
+    usdc.approve(address(vendingMachine), PRODUCT_PRICE * 3);
+    
+    // Purchase 3 items
+    vendingMachine.vendFromTrack(0, address(usdc), alice); // 20% stocker share
+    vendingMachine.vendFromTrack(1, address(usdc), alice); // 15% stocker share  
+    vendingMachine.vendFromTrack(2, address(usdc), alice); // 25% stocker share
+    vm.stopPrank();
+
+    assertEq(distributor.getCurrentBuyerCount(), 1); // Still only 1 unique buyer
+    
+    // Stocker revenue distributed to different stockers
+    assertEq(distributor.getStockerRevenue(stocker1, address(usdc)), 2 * 10 ** 18); // 20% of $10
+    assertEq(distributor.getStockerRevenue(stocker2, address(usdc)), 15 * 10 ** 17); // 15% of $10
+    assertEq(distributor.getStockerRevenue(stocker3, address(usdc)), 25 * 10 ** 17); // 25% of $10
+    
+    // Consumer revenue: $30 total - $6 stocker = $24
+    uint256 totalStockerRevenue = 2 * 10 ** 18 + 15 * 10 ** 17 + 25 * 10 ** 17; // $6 total
+    assertEq(distributor.getConsumerRevenue(address(usdc)), 30 * 10 ** 18 - totalStockerRevenue);
+    
+    // Alice should have $30 worth of vote tokens
+    assertEq(distributor.getEligibleBalance(alice), PRODUCT_PRICE * 3);
+  }
+
+  function testMultipleBuyers() public {
+    // Alice buys
+    vm.startPrank(alice);
+    usdc.approve(address(vendingMachine), PRODUCT_PRICE);
+    vendingMachine.vendFromTrack(0, address(usdc), alice);
+    vm.stopPrank();
+
+    // Bob buys
+    vm.startPrank(bob);
+    usdc.approve(address(vendingMachine), PRODUCT_PRICE);
+    vendingMachine.vendFromTrack(0, address(usdc), bob);
+    vm.stopPrank();
+
+    // Charlie buys
+    vm.startPrank(charlie);
+    usdc.approve(address(vendingMachine), PRODUCT_PRICE);
+    vendingMachine.vendFromTrack(0, address(usdc), charlie);
+    vm.stopPrank();
+
+    assertEq(distributor.getCurrentBuyerCount(), 3);
+    assertEq(distributor.getStockerRevenue(stocker1, address(usdc)), 6 * 10 ** 18); // 20% of $30 (all from track 0)
+    assertEq(distributor.getConsumerRevenue(address(usdc)), 24 * 10 ** 18); // 80% of $30
+  }
+
+  function testDistributionBeforeCycleComplete() public {
+    vm.startPrank(alice);
+    usdc.approve(address(vendingMachine), PRODUCT_PRICE);
+    vendingMachine.vendFromTrack(0, address(usdc), alice);
+    vm.stopPrank();
+
+    // Try to distribute before cycle is complete
+    vm.expectRevert(ITreasuryDistributor.CycleNotComplete.selector);
+    distributor.distribute();
+  }
+
+  function testSuccessfulDistribution() public {
+    // Make purchases
+    vm.startPrank(alice);
+    usdc.approve(address(vendingMachine), PRODUCT_PRICE * 2);
+    vendingMachine.vendFromTrack(0, address(usdc), alice); // $10 purchase, Alice gets $10 vote tokens
+    vendingMachine.vendFromTrack(0, address(usdc), alice); // Another $10, Alice now has $20 vote tokens
+    vm.stopPrank();
+
+    vm.startPrank(bob);
+    usdc.approve(address(vendingMachine), PRODUCT_PRICE);
+    vendingMachine.vendFromTrack(0, address(usdc), bob); // $10 purchase, Bob gets $10 vote tokens
+    vm.stopPrank();
+
+    // Total: $30 revenue, $6 to stocker (20%), $24 to consumers
+    // Alice has $20 vote tokens (66.67% of $30 total)
+    // Bob has $10 vote tokens (33.33% of $30 total)
+
+    // Move time forward to complete cycle
+    vm.warp(block.timestamp + CYCLE_LENGTH);
+
+    // Approve distributor to pull funds from vending machine
+    vm.prank(address(vendingMachine));
+    usdc.approve(address(distributor), type(uint256).max);
+
+    // Record balances before distribution
+    uint256 stocker1BalanceBefore = usdc.balanceOf(stocker1);
+    uint256 aliceBalanceBefore = usdc.balanceOf(alice);
+    uint256 bobBalanceBefore = usdc.balanceOf(bob);
+
+    // Execute distribution
+    vm.expectEmit(true, false, false, true);
+    emit DistributionExecuted(1, 2, block.timestamp);
+    
+    distributor.distribute();
+
+    // Check stocker1 received 20% of $30 = $6 (all purchases from track 0)
+    assertEq(usdc.balanceOf(stocker1), stocker1BalanceBefore + 6 * 10 ** 18);
+
+    // Check Alice received ~66.67% of $24 = $16
+    assertApproxEqAbs(usdc.balanceOf(alice), aliceBalanceBefore + 16 * 10 ** 18, 1e16); // Allow 0.01 token variance
+
+    // Check Bob received ~33.33% of $24 = $8
+    assertApproxEqAbs(usdc.balanceOf(bob), bobBalanceBefore + 8 * 10 ** 18, 1e16); // Allow 0.01 token variance
+
+    // Verify new cycle started
+    assertEq(distributor.getCurrentCycle(), 2);
+    assertEq(distributor.getCurrentBuyerCount(), 0);
+    assertEq(distributor.getStockerRevenue(stocker1, address(usdc)), 0);
+    assertEq(distributor.getConsumerRevenue(address(usdc)), 0);
+  }
+
+  function testDistributionWithDifferentStockerShares() public {
+    // Alice buys from track 0 (20% stocker share)
+    vm.startPrank(alice);
+    usdc.approve(address(vendingMachine), PRODUCT_PRICE);
+    vendingMachine.vendFromTrack(0, address(usdc), alice);
+    vm.stopPrank();
+
+    // Bob buys from track 1 (15% stocker share)
+    vm.startPrank(bob);
+    usdc.approve(address(vendingMachine), PRODUCT_PRICE);
+    vendingMachine.vendFromTrack(1, address(usdc), bob);
+    vm.stopPrank();
+
+    // Charlie buys from track 2 (25% stocker share)
+    vm.startPrank(charlie);
+    usdc.approve(address(vendingMachine), PRODUCT_PRICE);
+    vendingMachine.vendFromTrack(2, address(usdc), charlie);
+    vm.stopPrank();
+
+    // Stocker revenue per stocker:
+    assertEq(distributor.getStockerRevenue(stocker1, address(usdc)), 2 * 10 ** 18); // $2
+    assertEq(distributor.getStockerRevenue(stocker2, address(usdc)), 15 * 10 ** 17); // $1.5
+    assertEq(distributor.getStockerRevenue(stocker3, address(usdc)), 25 * 10 ** 17); // $2.5
+    // Total consumer revenue: $30 - $6 = $24
+    assertEq(distributor.getConsumerRevenue(address(usdc)), 24 * 10 ** 18);
+
+    // Move time forward and distribute
+    vm.warp(block.timestamp + CYCLE_LENGTH);
+    vm.prank(address(vendingMachine));
+    usdc.approve(address(distributor), type(uint256).max);
+    
+    distributor.distribute();
+
+    // Each buyer has $10 vote tokens, so each gets 1/3 of consumer revenue ($8)
+    assertApproxEqAbs(usdc.balanceOf(alice), 1000 * 10 ** 18 - PRODUCT_PRICE + 8 * 10 ** 18, 1e16);
+    assertApproxEqAbs(usdc.balanceOf(bob), 1000 * 10 ** 18 - PRODUCT_PRICE + 8 * 10 ** 18, 1e16);
+    assertApproxEqAbs(usdc.balanceOf(charlie), 1000 * 10 ** 18 - PRODUCT_PRICE + 8 * 10 ** 18, 1e16);
+  }
+
+  function testGetTimeUntilNextDistribution() public {
+    uint256 timeUntil = distributor.getTimeUntilNextDistribution();
+    assertEq(timeUntil, CYCLE_LENGTH);
+
+    // Move time forward
+    vm.warp(block.timestamp + CYCLE_LENGTH / 2);
+    timeUntil = distributor.getTimeUntilNextDistribution();
+    assertEq(timeUntil, CYCLE_LENGTH / 2);
+
+    // Move to end of cycle
+    vm.warp(block.timestamp + CYCLE_LENGTH / 2);
+    timeUntil = distributor.getTimeUntilNextDistribution();
+    assertEq(timeUntil, 0);
+  }
+
+  function testOnlyVendingMachineCanCallOnPurchase() public {
+    vm.expectRevert(ITreasuryDistributor.NotAuthorized.selector);
+    distributor.onPurchase(alice, address(usdc), PRODUCT_PRICE, STOCKER_SHARE_BPS, stocker1);
+  }
+
+  function testInitializerCanOnlyBeCalledOnce() public {
+    // Try to initialize again
+    vm.expectRevert(abi.encodeWithSignature("InvalidInitialization()"));
+    distributor.initialize(
+      address(voteToken),
+      address(vendingMachine),
+      CYCLE_LENGTH
+    );
+  }
+
+  function testRestockChangesStockerAndRevShare() public {
+    // New operator restocks track 0
+    address newOperator = address(0x7);
+    vm.startPrank(admin);
+    vendingMachine.grantRole(vendingMachine.OPERATOR_ROLE(), newOperator);
+    vm.stopPrank();
+
+    // Before restock, track 0 has stocker1
+    IVendingMachine.Track memory trackBefore = vendingMachine.getTrack(0);
+    assertEq(trackBefore.product.stockerAddress, stocker1);
+    assertEq(trackBefore.product.stockerShareBps, STOCKER_SHARE_BPS); // 20%
+
+    // First, let's buy some items to reduce stock
+    vm.startPrank(alice);
+    usdc.approve(address(vendingMachine), PRODUCT_PRICE * 5);
+    for (uint i = 0; i < 5; i++) {
+      vendingMachine.vendFromTrack(0, address(usdc), alice); // Buy 5 items
+    }
+    vm.stopPrank();
+    
+    // Stock should now be 95
+    assertEq(vendingMachine.getTrackInventory(0), 95);
+
+    // New operator restocks with different share
+    uint256 newShareBps = 3000; // 30%
+    vm.startPrank(newOperator);
+    vendingMachine.restockTrack(0, 5, newShareBps); // Add 5 to get back to 100
+    vm.stopPrank();
+
+    // After restock, track 0 should have newOperator as stocker
+    IVendingMachine.Track memory trackAfter = vendingMachine.getTrack(0);
+    assertEq(trackAfter.product.stockerAddress, newOperator);
+    assertEq(trackAfter.product.stockerShareBps, newShareBps);
+    assertEq(trackAfter.stock, 100); // Was 95, added 5
+
+    // Now when someone buys from track 0, newOperator should get revenue
+    vm.startPrank(alice);
+    usdc.approve(address(vendingMachine), PRODUCT_PRICE);
+    vendingMachine.vendFromTrack(0, address(usdc), alice);
+    vm.stopPrank();
+
+    // Check that newOperator is tracked for revenue
+    // stocker1 got revenue from the first 5 purchases (20% of $50 = $10)
+    assertEq(distributor.getStockerRevenue(stocker1, address(usdc)), 10 * 10 ** 18); 
+    // newOperator gets revenue from the last purchase (30% of $10 = $3)
+    assertEq(distributor.getStockerRevenue(newOperator, address(usdc)), 3 * 10 ** 18);
+    // Total consumer revenue: 80% of $50 + 70% of $10 = $40 + $7 = $47
+    assertEq(distributor.getConsumerRevenue(address(usdc)), 47 * 10 ** 18);
+  }
+}

--- a/test/unit/TreasuryDistributor.t.sol
+++ b/test/unit/TreasuryDistributor.t.sol
@@ -28,9 +28,7 @@ contract TreasuryDistributorTest is Test {
 
   address public admin = address(0x1);
   address public operator = address(0x2);
-  address public stocker1 = address(0x31);
-  address public stocker2 = address(0x32);
-  address public stocker3 = address(0x33);
+  address public stocker = address(0x3);
   address public alice = address(0x4);
   address public bob = address(0x5);
   address public charlie = address(0x6);
@@ -64,9 +62,9 @@ contract TreasuryDistributorTest is Test {
     acceptedTokens[0] = address(usdc);
 
     IVendingMachine.Product[] memory products = new IVendingMachine.Product[](3);
-    products[0] = IVendingMachine.Product('Coca Cola', 'ipfs://coca-cola', STOCKER_SHARE_BPS, stocker1);
-    products[1] = IVendingMachine.Product('Pepsi', 'ipfs://pepsi', 1500, stocker2); // 15% stocker share
-    products[2] = IVendingMachine.Product('Sprite', 'ipfs://sprite', 2500, stocker3); // 25% stocker share
+    products[0] = IVendingMachine.Product('Coca Cola', 'ipfs://coca-cola');
+    products[1] = IVendingMachine.Product('Pepsi', 'ipfs://pepsi');
+    products[2] = IVendingMachine.Product('Sprite', 'ipfs://sprite');
 
     uint256[] memory stocks = new uint256[](3);
     stocks[0] = 100;
@@ -96,6 +94,8 @@ contract TreasuryDistributorTest is Test {
     distributor.initialize(
       address(voteToken),
       address(vendingMachine),
+      stocker,
+      STOCKER_SHARE_BPS,
       CYCLE_LENGTH
     );
 
@@ -128,7 +128,7 @@ contract TreasuryDistributorTest is Test {
     vm.stopPrank();
 
     assertEq(distributor.getCurrentBuyerCount(), 1);
-    assertEq(distributor.getStockerRevenue(stocker1, address(usdc)), 2 * 10 ** 18); // 20% of $10
+    assertEq(distributor.getStockerRevenue(address(usdc)), 2 * 10 ** 18); // 20% of $10
     assertEq(distributor.getConsumerRevenue(address(usdc)), 8 * 10 ** 18); // 80% of $10
     assertEq(distributor.getEligibleBalance(alice), PRODUCT_PRICE);
   }
@@ -138,21 +138,16 @@ contract TreasuryDistributorTest is Test {
     usdc.approve(address(vendingMachine), PRODUCT_PRICE * 3);
     
     // Purchase 3 items
-    vendingMachine.vendFromTrack(0, address(usdc), alice); // 20% stocker share
-    vendingMachine.vendFromTrack(1, address(usdc), alice); // 15% stocker share  
-    vendingMachine.vendFromTrack(2, address(usdc), alice); // 25% stocker share
+    vendingMachine.vendFromTrack(0, address(usdc), alice);
+    vendingMachine.vendFromTrack(1, address(usdc), alice);
+    vendingMachine.vendFromTrack(2, address(usdc), alice);
     vm.stopPrank();
 
     assertEq(distributor.getCurrentBuyerCount(), 1); // Still only 1 unique buyer
     
-    // Stocker revenue distributed to different stockers
-    assertEq(distributor.getStockerRevenue(stocker1, address(usdc)), 2 * 10 ** 18); // 20% of $10
-    assertEq(distributor.getStockerRevenue(stocker2, address(usdc)), 15 * 10 ** 17); // 15% of $10
-    assertEq(distributor.getStockerRevenue(stocker3, address(usdc)), 25 * 10 ** 17); // 25% of $10
-    
-    // Consumer revenue: $30 total - $6 stocker = $24
-    uint256 totalStockerRevenue = 2 * 10 ** 18 + 15 * 10 ** 17 + 25 * 10 ** 17; // $6 total
-    assertEq(distributor.getConsumerRevenue(address(usdc)), 30 * 10 ** 18 - totalStockerRevenue);
+    // All purchases have same 20% stocker share
+    assertEq(distributor.getStockerRevenue(address(usdc)), 6 * 10 ** 18); // 20% of $30
+    assertEq(distributor.getConsumerRevenue(address(usdc)), 24 * 10 ** 18); // 80% of $30
     
     // Alice should have $30 worth of vote tokens
     assertEq(distributor.getEligibleBalance(alice), PRODUCT_PRICE * 3);
@@ -178,7 +173,7 @@ contract TreasuryDistributorTest is Test {
     vm.stopPrank();
 
     assertEq(distributor.getCurrentBuyerCount(), 3);
-    assertEq(distributor.getStockerRevenue(stocker1, address(usdc)), 6 * 10 ** 18); // 20% of $30 (all from track 0)
+    assertEq(distributor.getStockerRevenue(address(usdc)), 6 * 10 ** 18); // 20% of $30
     assertEq(distributor.getConsumerRevenue(address(usdc)), 24 * 10 ** 18); // 80% of $30
   }
 
@@ -218,7 +213,7 @@ contract TreasuryDistributorTest is Test {
     usdc.approve(address(distributor), type(uint256).max);
 
     // Record balances before distribution
-    uint256 stocker1BalanceBefore = usdc.balanceOf(stocker1);
+    uint256 stockerBalanceBefore = usdc.balanceOf(stocker);
     uint256 aliceBalanceBefore = usdc.balanceOf(alice);
     uint256 bobBalanceBefore = usdc.balanceOf(bob);
 
@@ -228,59 +223,20 @@ contract TreasuryDistributorTest is Test {
     
     distributor.distribute();
 
-    // Check stocker1 received 20% of $30 = $6 (all purchases from track 0)
-    assertEq(usdc.balanceOf(stocker1), stocker1BalanceBefore + 6 * 10 ** 18);
+    // Check stocker received 20% of $30 = $6
+    assertEq(usdc.balanceOf(stocker), stockerBalanceBefore + 6 * 10 ** 18);
 
     // Check Alice received ~66.67% of $24 = $16
-    assertApproxEqAbs(usdc.balanceOf(alice), aliceBalanceBefore + 16 * 10 ** 18, 1e16); // Allow 0.01 token variance
+    assertApproxEqAbs(usdc.balanceOf(alice), aliceBalanceBefore + 16 * 10 ** 18, 1e16);
 
     // Check Bob received ~33.33% of $24 = $8
-    assertApproxEqAbs(usdc.balanceOf(bob), bobBalanceBefore + 8 * 10 ** 18, 1e16); // Allow 0.01 token variance
+    assertApproxEqAbs(usdc.balanceOf(bob), bobBalanceBefore + 8 * 10 ** 18, 1e16);
 
     // Verify new cycle started
     assertEq(distributor.getCurrentCycle(), 2);
     assertEq(distributor.getCurrentBuyerCount(), 0);
-    assertEq(distributor.getStockerRevenue(stocker1, address(usdc)), 0);
+    assertEq(distributor.getStockerRevenue(address(usdc)), 0);
     assertEq(distributor.getConsumerRevenue(address(usdc)), 0);
-  }
-
-  function testDistributionWithDifferentStockerShares() public {
-    // Alice buys from track 0 (20% stocker share)
-    vm.startPrank(alice);
-    usdc.approve(address(vendingMachine), PRODUCT_PRICE);
-    vendingMachine.vendFromTrack(0, address(usdc), alice);
-    vm.stopPrank();
-
-    // Bob buys from track 1 (15% stocker share)
-    vm.startPrank(bob);
-    usdc.approve(address(vendingMachine), PRODUCT_PRICE);
-    vendingMachine.vendFromTrack(1, address(usdc), bob);
-    vm.stopPrank();
-
-    // Charlie buys from track 2 (25% stocker share)
-    vm.startPrank(charlie);
-    usdc.approve(address(vendingMachine), PRODUCT_PRICE);
-    vendingMachine.vendFromTrack(2, address(usdc), charlie);
-    vm.stopPrank();
-
-    // Stocker revenue per stocker:
-    assertEq(distributor.getStockerRevenue(stocker1, address(usdc)), 2 * 10 ** 18); // $2
-    assertEq(distributor.getStockerRevenue(stocker2, address(usdc)), 15 * 10 ** 17); // $1.5
-    assertEq(distributor.getStockerRevenue(stocker3, address(usdc)), 25 * 10 ** 17); // $2.5
-    // Total consumer revenue: $30 - $6 = $24
-    assertEq(distributor.getConsumerRevenue(address(usdc)), 24 * 10 ** 18);
-
-    // Move time forward and distribute
-    vm.warp(block.timestamp + CYCLE_LENGTH);
-    vm.prank(address(vendingMachine));
-    usdc.approve(address(distributor), type(uint256).max);
-    
-    distributor.distribute();
-
-    // Each buyer has $10 vote tokens, so each gets 1/3 of consumer revenue ($8)
-    assertApproxEqAbs(usdc.balanceOf(alice), 1000 * 10 ** 18 - PRODUCT_PRICE + 8 * 10 ** 18, 1e16);
-    assertApproxEqAbs(usdc.balanceOf(bob), 1000 * 10 ** 18 - PRODUCT_PRICE + 8 * 10 ** 18, 1e16);
-    assertApproxEqAbs(usdc.balanceOf(charlie), 1000 * 10 ** 18 - PRODUCT_PRICE + 8 * 10 ** 18, 1e16);
   }
 
   function testGetTimeUntilNextDistribution() public {
@@ -300,7 +256,7 @@ contract TreasuryDistributorTest is Test {
 
   function testOnlyVendingMachineCanCallOnPurchase() public {
     vm.expectRevert(ITreasuryDistributor.NotAuthorized.selector);
-    distributor.onPurchase(alice, address(usdc), PRODUCT_PRICE, STOCKER_SHARE_BPS, stocker1);
+    distributor.onPurchase(alice, address(usdc), PRODUCT_PRICE);
   }
 
   function testInitializerCanOnlyBeCalledOnce() public {
@@ -309,57 +265,9 @@ contract TreasuryDistributorTest is Test {
     distributor.initialize(
       address(voteToken),
       address(vendingMachine),
+      stocker,
+      STOCKER_SHARE_BPS,
       CYCLE_LENGTH
     );
-  }
-
-  function testRestockChangesStockerAndRevShare() public {
-    // New operator restocks track 0
-    address newOperator = address(0x7);
-    vm.startPrank(admin);
-    vendingMachine.grantRole(vendingMachine.OPERATOR_ROLE(), newOperator);
-    vm.stopPrank();
-
-    // Before restock, track 0 has stocker1
-    IVendingMachine.Track memory trackBefore = vendingMachine.getTrack(0);
-    assertEq(trackBefore.product.stockerAddress, stocker1);
-    assertEq(trackBefore.product.stockerShareBps, STOCKER_SHARE_BPS); // 20%
-
-    // First, let's buy some items to reduce stock
-    vm.startPrank(alice);
-    usdc.approve(address(vendingMachine), PRODUCT_PRICE * 5);
-    for (uint i = 0; i < 5; i++) {
-      vendingMachine.vendFromTrack(0, address(usdc), alice); // Buy 5 items
-    }
-    vm.stopPrank();
-    
-    // Stock should now be 95
-    assertEq(vendingMachine.getTrackInventory(0), 95);
-
-    // New operator restocks with different share
-    uint256 newShareBps = 3000; // 30%
-    vm.startPrank(newOperator);
-    vendingMachine.restockTrack(0, 5, newShareBps); // Add 5 to get back to 100
-    vm.stopPrank();
-
-    // After restock, track 0 should have newOperator as stocker
-    IVendingMachine.Track memory trackAfter = vendingMachine.getTrack(0);
-    assertEq(trackAfter.product.stockerAddress, newOperator);
-    assertEq(trackAfter.product.stockerShareBps, newShareBps);
-    assertEq(trackAfter.stock, 100); // Was 95, added 5
-
-    // Now when someone buys from track 0, newOperator should get revenue
-    vm.startPrank(alice);
-    usdc.approve(address(vendingMachine), PRODUCT_PRICE);
-    vendingMachine.vendFromTrack(0, address(usdc), alice);
-    vm.stopPrank();
-
-    // Check that newOperator is tracked for revenue
-    // stocker1 got revenue from the first 5 purchases (20% of $50 = $10)
-    assertEq(distributor.getStockerRevenue(stocker1, address(usdc)), 10 * 10 ** 18); 
-    // newOperator gets revenue from the last purchase (30% of $10 = $3)
-    assertEq(distributor.getStockerRevenue(newOperator, address(usdc)), 3 * 10 ** 18);
-    // Total consumer revenue: 80% of $50 + 70% of $10 = $40 + $7 = $47
-    assertEq(distributor.getConsumerRevenue(address(usdc)), 47 * 10 ** 18);
   }
 }

--- a/test/unit/TreasuryDistributor.t.sol
+++ b/test/unit/TreasuryDistributor.t.sol
@@ -33,19 +33,31 @@ contract TreasuryDistributorTest is Test {
 
   uint256 constant CYCLE_LENGTH = 7 days;
   uint256 constant PRODUCT_PRICE = 10 * 10 ** 18; // $10
+  uint256 constant DISTRIBUTION_PERCENTAGE = 8000; // 80%
 
   event PurchaseTracked(
     address indexed buyer,
     address indexed token,
     uint256 amount,
-    uint256 stockerAmount,
-    uint256 consumerAmount
+    uint256 distributedAmount,
+    uint256 retainedAmount
   );
 
   event DistributionExecuted(
     uint256 indexed cycle,
     uint256 buyerCount,
     uint256 timestamp
+  );
+
+  event DistributionPercentageUpdated(
+    uint256 oldPercentage,
+    uint256 newPercentage
+  );
+
+  event RetainedRevenueWithdrawn(
+    address indexed token,
+    uint256 amount,
+    address indexed recipient
   );
 
   function setUp() public {
@@ -86,12 +98,13 @@ contract TreasuryDistributorTest is Test {
 
     voteToken = vendingMachine.voteToken();
 
-    // Deploy and initialize TreasuryDistributor
+    // Deploy and initialize TreasuryDistributor with 80% distribution percentage
     distributor = new TreasuryDistributor();
     distributor.initialize(
       address(voteToken),
       address(vendingMachine),
-      CYCLE_LENGTH
+      CYCLE_LENGTH,
+      DISTRIBUTION_PERCENTAGE // 80% distributed, 20% retained
     );
 
     // Configure VendingMachine
@@ -110,21 +123,25 @@ contract TreasuryDistributorTest is Test {
     vm.startPrank(alice);
     usdc.approve(address(vendingMachine), PRODUCT_PRICE);
     
+    // 80% distributable, 20% retained
+    uint256 distributableAmount = (PRODUCT_PRICE * DISTRIBUTION_PERCENTAGE) / 10000;
+    uint256 retainedAmount = PRODUCT_PRICE - distributableAmount;
+    
     vm.expectEmit(true, true, false, true);
     emit PurchaseTracked(
       alice,
       address(usdc),
       PRODUCT_PRICE,
-      0, // No stocker amount
-      PRODUCT_PRICE // All revenue goes to consumers
+      distributableAmount,
+      retainedAmount
     );
     
     vendingMachine.vendFromTrack(0, address(usdc), alice);
     vm.stopPrank();
 
     assertEq(distributor.getCurrentBuyerCount(), 1);
-    assertEq(distributor.getStockerRevenue(address(usdc)), 0); // No stocker revenue
-    assertEq(distributor.getConsumerRevenue(address(usdc)), PRODUCT_PRICE); // All to consumers
+    assertEq(distributor.getDistributableRevenue(address(usdc)), distributableAmount);
+    assertEq(distributor.getRetainedRevenue(address(usdc)), retainedAmount);
     assertEq(distributor.getEligibleBalance(alice), PRODUCT_PRICE);
   }
 
@@ -138,8 +155,13 @@ contract TreasuryDistributorTest is Test {
     vendingMachine.vendFromTrack(2, address(usdc), alice);
     vm.stopPrank();
 
+    uint256 totalRevenue = PRODUCT_PRICE * 3;
+    uint256 distributableAmount = (totalRevenue * DISTRIBUTION_PERCENTAGE) / 10000;
+    uint256 retainedAmount = totalRevenue - distributableAmount;
+
     assertEq(distributor.getCurrentBuyerCount(), 1); // Still only 1 unique buyer
-    assertEq(distributor.getConsumerRevenue(address(usdc)), PRODUCT_PRICE * 3); // All to consumers
+    assertEq(distributor.getDistributableRevenue(address(usdc)), distributableAmount);
+    assertEq(distributor.getRetainedRevenue(address(usdc)), retainedAmount);
     
     // Alice should have $30 worth of vote tokens
     assertEq(distributor.getEligibleBalance(alice), PRODUCT_PRICE * 3);
@@ -164,8 +186,13 @@ contract TreasuryDistributorTest is Test {
     vendingMachine.vendFromTrack(0, address(usdc), charlie);
     vm.stopPrank();
 
+    uint256 totalRevenue = 30 * 10 ** 18;
+    uint256 distributableAmount = (totalRevenue * DISTRIBUTION_PERCENTAGE) / 10000;
+    uint256 retainedAmount = totalRevenue - distributableAmount;
+
     assertEq(distributor.getCurrentBuyerCount(), 3);
-    assertEq(distributor.getConsumerRevenue(address(usdc)), 30 * 10 ** 18); // $30 total
+    assertEq(distributor.getDistributableRevenue(address(usdc)), distributableAmount);
+    assertEq(distributor.getRetainedRevenue(address(usdc)), retainedAmount);
   }
 
   function testDistributionBeforeCycleComplete() public {
@@ -193,6 +220,8 @@ contract TreasuryDistributorTest is Test {
     vm.stopPrank();
 
     // Total: $30 revenue
+    // Distributable: $24 (80% of $30)
+    // Retained: $6 (20% of $30)
     // Alice has $20 vote tokens (66.67% of $30 total)
     // Bob has $10 vote tokens (33.33% of $30 total)
 
@@ -213,16 +242,19 @@ contract TreasuryDistributorTest is Test {
     
     distributor.distribute();
 
-    // Check Alice received ~66.67% of $30 = $20
-    assertApproxEqAbs(usdc.balanceOf(alice), aliceBalanceBefore + 20 * 10 ** 18, 1e16);
+    // Check Alice received ~66.67% of $24 = $16
+    assertApproxEqAbs(usdc.balanceOf(alice), aliceBalanceBefore + 16 * 10 ** 18, 1e16);
 
-    // Check Bob received ~33.33% of $30 = $10
-    assertApproxEqAbs(usdc.balanceOf(bob), bobBalanceBefore + 10 * 10 ** 18, 1e16);
+    // Check Bob received ~33.33% of $24 = $8
+    assertApproxEqAbs(usdc.balanceOf(bob), bobBalanceBefore + 8 * 10 ** 18, 1e16);
+
+    // Check that $6 remains as retained revenue
+    assertEq(distributor.getRetainedRevenue(address(usdc)), 6 * 10 ** 18);
 
     // Verify new cycle started
     assertEq(distributor.getCurrentCycle(), 2);
     assertEq(distributor.getCurrentBuyerCount(), 0);
-    assertEq(distributor.getConsumerRevenue(address(usdc)), 0);
+    assertEq(distributor.getDistributableRevenue(address(usdc)), 0);
   }
 
   function testGetTimeUntilNextDistribution() public {
@@ -251,7 +283,8 @@ contract TreasuryDistributorTest is Test {
     distributor.initialize(
       address(voteToken),
       address(vendingMachine),
-      CYCLE_LENGTH
+      CYCLE_LENGTH,
+      DISTRIBUTION_PERCENTAGE
     );
   }
 
@@ -268,8 +301,8 @@ contract TreasuryDistributorTest is Test {
     assertEq(distributor.getCurrentBuyerCount(), 0);
     
     // No revenue should be tracked at all (onPurchase not called)
-    assertEq(distributor.getStockerRevenue(address(usdc)), 0);
-    assertEq(distributor.getConsumerRevenue(address(usdc)), 0);
+    assertEq(distributor.getDistributableRevenue(address(usdc)), 0);
+    assertEq(distributor.getRetainedRevenue(address(usdc)), 0);
     
     // No eligible balance for address(0)
     assertEq(distributor.getEligibleBalance(address(0)), 0);
@@ -296,7 +329,12 @@ contract TreasuryDistributorTest is Test {
     assertEq(distributor.getCurrentBuyerCount(), 2);
     
     // Revenue only from purchases with recipients (2 out of 3)
-    assertEq(distributor.getConsumerRevenue(address(usdc)), 20 * 10 ** 18); // $20 (2 purchases)
+    uint256 totalRevenue = 20 * 10 ** 18; // $20 from 2 purchases
+    uint256 distributableAmount = (totalRevenue * DISTRIBUTION_PERCENTAGE) / 10000;
+    uint256 retainedAmount = totalRevenue - distributableAmount;
+    
+    assertEq(distributor.getDistributableRevenue(address(usdc)), distributableAmount);
+    assertEq(distributor.getRetainedRevenue(address(usdc)), retainedAmount);
     
     // Move time forward and distribute
     vm.warp(block.timestamp + CYCLE_LENGTH);
@@ -308,12 +346,170 @@ contract TreasuryDistributorTest is Test {
     
     distributor.distribute();
     
-    // Alice and Bob split the $20 revenue
-    // Alice has $10 vote tokens, Bob has $10 vote tokens (50/50 split)
-    assertApproxEqAbs(usdc.balanceOf(alice), aliceBalanceBefore + 10 * 10 ** 18, 1e16);
-    assertApproxEqAbs(usdc.balanceOf(bob), bobBalanceBefore + 10 * 10 ** 18, 1e16);
+    // Alice and Bob split the distributable revenue
+    // Both have $10 vote tokens (50/50 split)
+    // Distributable: $16 (80% of $20)
+    assertApproxEqAbs(usdc.balanceOf(alice), aliceBalanceBefore + 8 * 10 ** 18, 1e16);
+    assertApproxEqAbs(usdc.balanceOf(bob), bobBalanceBefore + 8 * 10 ** 18, 1e16);
     
     // The entire $10 from the no-recipient purchase stays in vending machine
     // (no revenue sharing at all for that purchase)
+  }
+
+  function testMultiplePurchasesSameBuyerSameCycle() public {
+    // This test specifically verifies that multiple purchases by the same buyer
+    // in the same cycle are properly accumulated (addressing review comment)
+    
+    vm.startPrank(alice);
+    usdc.approve(address(vendingMachine), PRODUCT_PRICE * 3);
+    
+    // First purchase - Alice gets $10 vote tokens
+    vendingMachine.vendFromTrack(0, address(usdc), alice);
+    assertEq(voteToken.balanceOf(alice), PRODUCT_PRICE);
+    assertEq(distributor.getEligibleBalance(alice), PRODUCT_PRICE);
+    
+    // Second purchase - Alice gets another $10, total $20
+    vendingMachine.vendFromTrack(1, address(usdc), alice);
+    assertEq(voteToken.balanceOf(alice), PRODUCT_PRICE * 2);
+    assertEq(distributor.getEligibleBalance(alice), PRODUCT_PRICE * 2); // Should be cumulative
+    
+    // Third purchase - Alice gets another $10, total $30
+    vendingMachine.vendFromTrack(2, address(usdc), alice);
+    assertEq(voteToken.balanceOf(alice), PRODUCT_PRICE * 3);
+    assertEq(distributor.getEligibleBalance(alice), PRODUCT_PRICE * 3); // Should be cumulative
+    
+    vm.stopPrank();
+    
+    // Bob makes one purchase
+    vm.startPrank(bob);
+    usdc.approve(address(vendingMachine), PRODUCT_PRICE);
+    vendingMachine.vendFromTrack(0, address(usdc), bob);
+    vm.stopPrank();
+    
+    // Move time forward and distribute
+    vm.warp(block.timestamp + CYCLE_LENGTH);
+    vm.prank(address(vendingMachine));
+    usdc.approve(address(distributor), type(uint256).max);
+    
+    uint256 aliceBalanceBefore = usdc.balanceOf(alice);
+    uint256 bobBalanceBefore = usdc.balanceOf(bob);
+    
+    distributor.distribute();
+    
+    // Total revenue: $40 ($30 from Alice, $10 from Bob)
+    // Distributable: $32 (80% of $40)
+    // Alice should get 75% (30/40) of $32 = $24
+    // Bob should get 25% (10/40) of $32 = $8
+    assertApproxEqAbs(usdc.balanceOf(alice), aliceBalanceBefore + 24 * 10 ** 18, 1e16);
+    assertApproxEqAbs(usdc.balanceOf(bob), bobBalanceBefore + 8 * 10 ** 18, 1e16);
+  }
+
+  function testSetDistributionPercentage() public {
+    // Only owner can change distribution percentage
+    vm.expectRevert(ITreasuryDistributor.NotAuthorized.selector);
+    vm.prank(alice);
+    distributor.setDistributionPercentage(5000);
+
+    // Owner can change distribution percentage
+    vm.prank(admin);
+    vm.expectEmit(false, false, false, true);
+    emit DistributionPercentageUpdated(8000, 5000);
+    distributor.setDistributionPercentage(5000);
+    
+    assertEq(distributor.getDistributionPercentage(), 5000);
+
+    // Test with new percentage
+    vm.startPrank(alice);
+    usdc.approve(address(vendingMachine), PRODUCT_PRICE);
+    vendingMachine.vendFromTrack(0, address(usdc), alice);
+    vm.stopPrank();
+
+    // Should be 50/50 split now
+    assertEq(distributor.getDistributableRevenue(address(usdc)), 5 * 10 ** 18);
+    assertEq(distributor.getRetainedRevenue(address(usdc)), 5 * 10 ** 18);
+  }
+
+  function testWithdrawRetainedRevenue() public {
+    // Make some purchases to accumulate retained revenue
+    vm.startPrank(alice);
+    usdc.approve(address(vendingMachine), PRODUCT_PRICE * 2);
+    vendingMachine.vendFromTrack(0, address(usdc), alice);
+    vendingMachine.vendFromTrack(1, address(usdc), alice);
+    vm.stopPrank();
+
+    // Total revenue: $20
+    // Retained: $4 (20% of $20)
+    assertEq(distributor.getRetainedRevenue(address(usdc)), 4 * 10 ** 18);
+
+    // Only owner can withdraw
+    vm.expectRevert(ITreasuryDistributor.NotAuthorized.selector);
+    vm.prank(alice);
+    distributor.withdrawRetainedRevenue(address(usdc), alice);
+
+    // Owner withdraws retained revenue
+    vm.prank(address(vendingMachine));
+    usdc.approve(address(distributor), type(uint256).max);
+
+    uint256 adminBalanceBefore = usdc.balanceOf(admin);
+    
+    vm.prank(admin);
+    vm.expectEmit(true, false, false, true);
+    emit RetainedRevenueWithdrawn(address(usdc), 4 * 10 ** 18, admin);
+    distributor.withdrawRetainedRevenue(address(usdc), admin);
+
+    // Check admin received the retained revenue
+    assertEq(usdc.balanceOf(admin), adminBalanceBefore + 4 * 10 ** 18);
+    
+    // Retained revenue should be zero now
+    assertEq(distributor.getRetainedRevenue(address(usdc)), 0);
+
+    // Cannot withdraw again (no revenue to withdraw)
+    vm.expectRevert(ITreasuryDistributor.NoRevenueToWithdraw.selector);
+    vm.prank(admin);
+    distributor.withdrawRetainedRevenue(address(usdc), admin);
+  }
+
+  function testInvalidDistributionPercentage() public {
+    // Try to set percentage > 100%
+    vm.prank(admin);
+    vm.expectRevert(ITreasuryDistributor.InvalidPercentage.selector);
+    distributor.setDistributionPercentage(10001);
+  }
+
+  function testZeroDistributionPercentage() public {
+    // Set to 0% distribution (100% retained)
+    vm.prank(admin);
+    distributor.setDistributionPercentage(0);
+
+    vm.startPrank(alice);
+    usdc.approve(address(vendingMachine), PRODUCT_PRICE);
+    vendingMachine.vendFromTrack(0, address(usdc), alice);
+    vm.stopPrank();
+
+    // All revenue should be retained
+    assertEq(distributor.getDistributableRevenue(address(usdc)), 0);
+    assertEq(distributor.getRetainedRevenue(address(usdc)), PRODUCT_PRICE);
+
+    // Distribution should work but distribute nothing
+    vm.warp(block.timestamp + CYCLE_LENGTH);
+    distributor.distribute();
+    
+    // Alice started with 1000e18, spent 10e18 on purchase, should still have 990e18 (no distribution)
+    assertEq(usdc.balanceOf(alice), 990 * 10 ** 18); // No distribution
+  }
+
+  function testFullDistributionPercentage() public {
+    // Set to 100% distribution (0% retained)
+    vm.prank(admin);
+    distributor.setDistributionPercentage(10000);
+
+    vm.startPrank(alice);
+    usdc.approve(address(vendingMachine), PRODUCT_PRICE);
+    vendingMachine.vendFromTrack(0, address(usdc), alice);
+    vm.stopPrank();
+
+    // All revenue should be distributable
+    assertEq(distributor.getDistributableRevenue(address(usdc)), PRODUCT_PRICE);
+    assertEq(distributor.getRetainedRevenue(address(usdc)), 0);
   }
 }


### PR DESCRIPTION
## Summary
This PR introduces a flexible, configurable revenue distribution system for the TreasuryDistributor contract. Revenue can now be split between vote token holders (distributable) and the contract owner (retained), with the percentage being adjustable by the owner.

## Key Features

### Revenue Distribution Configuration
- **Configurable distribution percentage** in basis points (e.g., 8000 = 80%)
- Owner can dynamically adjust the distribution/retention split via `setDistributionPercentage()`
- Default: 80% distributed to vote token holders, 20% retained for owner
- Support for edge cases: 0% (all retained) to 100% (all distributed)

### Owner Withdrawal System
- New `withdrawRetainedRevenue()` function for owner to claim retained revenue
- Revenue is only collected from the vending machine when actually withdrawn
- Separate tracking of `distributableRevenue` and `retainedRevenue` per token

### Code Quality Improvements
- Removed all stocker-related logic for a cleaner, simpler revenue model
- Added comprehensive NatSpec documentation for all functions, events, and errors
- Optimized token array access using `getAcceptedTokens()` directly instead of while loops
- Fixed eligibleBalance tracking to only subtract old values for existing cycle buyers
- Consolidated internal reset functions (`_resetDistributableRevenue` merged into `_resetCycleState`)
- Removed deprecated functions (`getStockerRevenue`, `getConsumerRevenue`)
- Removed `acceptedTokenList(uint256)` from interface (made private in implementation)
- Removed redundant address(0) validation in VendingMachine

## Breaking Changes
- `TreasuryDistributor.initialize()` now requires a 4th parameter: `_distributionPercentageBps`
- Removed `getStockerRevenue()` and `getConsumerRevenue()` - use `getDistributableRevenue()` and `getRetainedRevenue()` instead
- `PurchaseTracked` event now emits `distributedAmount` and `retainedAmount` instead of `stockerAmount` and `consumerAmount`
- `acceptedTokenList(uint256 index)` removed from `IVendingMachine` interface

## New Events
- `DistributionPercentageUpdated(uint256 oldPercentage, uint256 newPercentage)`
- `RetainedRevenueWithdrawn(address indexed token, uint256 amount, address indexed recipient)`

## New Errors
- `InsufficientBalance()` - thrown when withdrawal would exceed available balance

## Testing
- All 16 existing tests passing
- Added new test coverage for:
  - Distribution percentage changes (`testSetDistributionPercentage`)
  - Owner withdrawal functionality (`testWithdrawRetainedRevenue`)
  - Edge cases: 0% and 100% distribution (`testZeroDistributionPercentage`, `testFullDistributionPercentage`)

## Migration Guide

### For Deployment Scripts
```solidity
// Before
distributor.initialize(voteToken, vendingMachine, cycleLength);

// After
distributor.initialize(voteToken, vendingMachine, cycleLength, 8000); // 80% distribution
```

### For Revenue Queries
```solidity
// Before
uint256 consumerRev = distributor.getConsumerRevenue(token);

// After
uint256 distributableRev = distributor.getDistributableRevenue(token);
uint256 retainedRev = distributor.getRetainedRevenue(token);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)